### PR TITLE
Compabitility with Julia v0.5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: julia
 julia:
-  - 0.4
   - 0.5
   - nightly
 notifications:
@@ -13,9 +12,5 @@ before_install:
   - export CONDA_PYTHON=`julia -e 'import Conda; print(Conda.PREFIX)'`
   - export PATH=$CONDA_PYTHON/bin:$PATH
   - export LD_LIBRARY_PATH=$CONDA_PYTHON/lib
-#script: # use the default script setting
-#  - julia -e 'Pkg.init(); run(`ln -s $(pwd()) $(Pkg.dir("YT"))`); Pkg.pin("YT"); Pkg.resolve()'
-#  - julia -e 'using YT; @assert isdefined(:YT); @assert typeof(YT) === Module'
-#  - julia --code-coverage test/runtests.jl
 after_success:
   - julia -e 'cd(Pkg.dir("YT")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.5
 PyCall 1.1.2
 PyPlot 2.1.1
 SymPy 0.2.31

--- a/doc/source/installing_yt.rst
+++ b/doc/source/installing_yt.rst
@@ -1,7 +1,7 @@
 Installing ``YT``
 =================
 
-``YT`` version 0.3 requires Julia version 0.4 or later, and may be installed just like any other Julia package:
+``YT`` version 0.4 requires Julia version 0.5 or later, and may be installed just like any other Julia package:
 
 .. code-block:: jlcon
 
@@ -13,7 +13,7 @@ This will also install the following dependencies, if you don't have them instal
 * `PyPlot <http://github.com/stevengj/PyPlot.jl>`_
 * `SymPy <http://github.com/jverzani/SymPy.jl>`_
 
-However, for ``YT`` to work, ``yt`` itself must be installed. ``YT`` version 0.3 requires ``yt`` version 3.2.2
+However, for ``YT`` to work, ``yt`` itself must be installed. ``YT`` version 0.4 requires ``yt`` version 3.3.1
 or higher. The best ways to install ``yt`` are via the
 `install script <http://yt-project.org/#getyt>`_ or via the
 `Anaconda Python Distribution <https://store.continuum.io/cshop/anaconda/>`_.
@@ -40,4 +40,3 @@ While not required, the following Julia packages are useful when working with da
 * `Winston <https://github.com/nolta/Winston.jl>`_ (a plotting package)
 * `IJulia <https://github.com/JuliaLang/IJulia.jl>`_ (Julia backend for IPython/Jupyter)
 * `Glob <https://github.com/vtjnash/Glob.jl>`_ (find pathnames matching specified patterns, useful for constructing arrays of filenames)
-

--- a/doc/source/installing_yt.rst
+++ b/doc/source/installing_yt.rst
@@ -13,10 +13,9 @@ This will also install the following dependencies, if you don't have them instal
 * `PyPlot <http://github.com/stevengj/PyPlot.jl>`_
 * `SymPy <http://github.com/jverzani/SymPy.jl>`_
 
-However, for ``YT`` to work, ``yt`` itself must be installed. ``YT`` version 0.4 requires ``yt`` version 3.3.1
-or higher. The best ways to install ``yt`` are via the
-`install script <http://yt-project.org/#getyt>`_ or via the
-`Anaconda Python Distribution <https://store.continuum.io/cshop/anaconda/>`_.
+However, for ``YT`` to work, ``yt`` itself must be installed. ``YT`` version 0.4
+requires ``yt`` version 3.3.1 or higher. The best ways to install ``yt`` are via
+`pip <https://pip.pypa.io/>`_ or the `Anaconda Python Distribution <https://store.continuum.io/cshop/anaconda/>`_.
 
 Once ``YT`` is installed, either
 

--- a/doc/source/users_guide/arrays.rst
+++ b/doc/source/users_guide/arrays.rst
@@ -184,7 +184,7 @@ A ``YTArray`` can be saved to an `HDF5 <http://www.hdfgroup.org>`_ file for re-l
 
 .. code-block:: julia
 
-    function write_hdf5(a::YTArray, filename::ASCIIString; dataset_name=nothing, info=nothing)
+    function write_hdf5(a::YTArray, filename::String; dataset_name=nothing, info=nothing)
 
 where ``dataset_name`` is the name of the dataset to store the array in (defaults to ``"array_data"``), and ``info``
 is an optional dictionary which can be stored as dataset attributes to provide additional information:

--- a/doc/source/users_guide/data_containers.rst
+++ b/doc/source/users_guide/data_containers.rst
@@ -20,14 +20,14 @@ A ``Length``-type argument is for length quantities such as ``radius`` or ``heig
 one of the following:
 
   * A ``Float64`` number. If so, the assumed units are ``"code_length"``.
-  * A ``Tuple{Float64, ASCIIString}``, e.g., ``(1.5, "Mpc")``.
+  * A ``Tuple{Float64, String}``, e.g., ``(1.5, "Mpc")``.
   * A ``YTQuantity``.
 
 A ``Center``-type argument is for the ``center`` of an object and can be one of the following:
 
-  * An ``ASCIIString``, e.g., ``"max"`` (or ``"m"``), ``"center"`` (or ``"c"``),
+  * An ``String``, e.g., ``"max"`` (or ``"m"``), ``"center"`` (or ``"c"``),
     corresponding to the point with maximum density and the center of the domain, respectively.
-  * A ``Tuple{ASCIIString, ASCIIString}``, e.g. ``("min", "temperature")``,
+  * A ``Tuple{String, String}``, e.g. ``("min", "temperature")``,
     or ``("max","velocity_x")``, corresponding to maxima and minima of specific fields.
   * An ``Array`` of ``Float64`` numbers. If so, the assumed units are ``"code_length"``.
   * A ``YTArray``.
@@ -217,7 +217,7 @@ string ("x","y","z") or an integer (0,1,2), centered at some coordinate
 
 .. code-block:: julia
 
-  function Slice(ds::Dataset, axis::Union{Integer,ASCIIString},
+  function Slice(ds::Dataset, axis::Union{Integer,String},
                  coord::Float64;
                  field_parameters=nothing,
                  data_source=nothing)
@@ -237,7 +237,7 @@ A ``Proj`` is an integral of a given ``field`` along a sight line corresponding 
 
 .. code-block:: julia
 
-  function Proj(ds::Dataset, field, axis::Union{Integer,ASCIIString};
+  function Proj(ds::Dataset, field, axis::Union{Integer,String};
                 weight_field=nothing, data_source=nothing,
                 field_parameters=nothing, method=nothing)
 
@@ -307,7 +307,7 @@ which is determined by an array of ``conditionals`` on fields in the container.
 .. code-block:: julia
 
   function CutRegion(dc::DataContainer,
-                     conditionals::Array{ASCIIString,1}
+                     conditionals::Array{String,1}
                      field_parameters=nothing)
 
 ``conditionals`` is a list of conditionals that will be evaluated. In the namespace available,

--- a/doc/source/users_guide/datasets.rst
+++ b/doc/source/users_guide/datasets.rst
@@ -181,7 +181,7 @@ the field value and the point of the extremum:
     These methods apply to ``Dataset``\ s loaded from disk files and to ``Dataset``\ s created
     from generic in-memory data. For details on how to create the latter,
     see `In-Memory Datasets <in_memory_datasets.html>`_.
-    
+
 Dataset Series
 --------------
 
@@ -190,10 +190,10 @@ to iterate over them:
 
 .. code-block:: julia
 
-    function DatasetSeries(fns::Array{ASCIIString,1}))
-    
+    function DatasetSeries(fns::Array{String,1}))
+
 where ``fns`` is an ``Array`` of strings corresponding to the filenames of the datasets to be
-loaded. Such a list of filenames could be generated using the |glob_package|_. Once a 
+loaded. Such a list of filenames could be generated using the |glob_package|_. Once a
 ``DatasetSeries`` object is created, it can be iterated over, such as in this script:
 
 .. code-block:: julia
@@ -201,18 +201,17 @@ loaded. Such a list of filenames could be generated using the |glob_package|_. O
     using YT
     using Glob
     fns = sort(glob("sloshing_low_res_hdf5_plt_cnt_0*"))
-    
+
     time = YTQuantity[]
     max_dens = YTQuantity[]
-    
+
     ts = DatasetSeries(fns)
-    
+
     for ds in ts
         append!(time, [ds.current_time])
         sp = Sphere(ds, "c", (100.,"kpc"))
         append!(max_dens, [maximum(sp["density"])])
     end
-           
+
     time = YTArray(time)
     max_dens = YTArray(max_dens)
-

--- a/doc/source/users_guide/in_memory_datasets.rst
+++ b/doc/source/users_guide/in_memory_datasets.rst
@@ -183,7 +183,7 @@ Then, call ``load_amr_grids``:
 
 .. code:: jlcon
 
-    ds = YT.load_amr_grids(grid_data, [32, 32, 32]; field_units=field_units)
+    ds = YT.load_amr_grids(grid_data, [32, 32, 32])
 
 ``load_amr_grids`` also takes the same keywords ``bbox`` and
 ``sim_time`` as ``load_uniform_grid``. We could have also specified the

--- a/src/YT.jl
+++ b/src/YT.jl
@@ -90,7 +90,11 @@ import .profiles: YTProfile, set_x_unit, set_y_unit, set_z_unit,
     set_field_unit, variance
 import .dataset_series: DatasetSeries
 
-@doc doc""" Enable the plugins defined in the plugin file.""" ->
+"""
+    enable_plugins()
+
+Enable the plugins defined in the plugin file.
+"""
 enable_plugins = yt.enable_plugins
 
 type YTConfig
@@ -108,56 +112,71 @@ end
 
 show(ytcfg::YTConfig) = typeof(ytcfg)
 
-@doc doc""" The yt configuration object.""" ->
 ytcfg = YTConfig(ytconfig.ytcfg)
 
-@doc doc""" `load` a `Dataset` object from the file `fn::String`.""" ->
+"""
+    load(fn::String; args...)
+
+Load a `Dataset` object from a file.
+"""
 load(fn::String; args...) = Dataset(ytconv.load(fn; args...))
 
 # Stream datasets
 
-@doc doc"""
+"""
+    load_uniform_grid(data::Dict{Any,Any}, domain_dimensions::Array;
+                      length_unit=nothing, bbox=nothing,
+                      nprocs=1, sim_time=0.0, mass_unit=nothing,
+                      time_unit=nothing, velocity_unit=nothing,
+                      magnetic_unit=nothing,
+                      periodicity=(true, true, true),
+                      geometry="cartesian")
 
-      Load a uniform grid of in-memory data into yt.
+Load a uniform grid of in-memory data into yt.
 
-      This should allow a uniform grid of data to be loaded directly into yt and
-      analyzed as would any others.  This comes with several caveats:
+This should allow a uniform grid of data to be loaded directly into yt and
+analyzed. This comes with several caveats:
 
-      * Units will be incorrect unless the unit system is explicitly
-        specified.
-      * Particles may be difficult to integrate.
+* Units will be incorrect unless the unit system is explicitly
+  specified.
+* Particles may be difficult to integrate.
 
-      Particle fields are detected as one-dimensional fields. The number of
-      particles is set by the `number_of_particles` key in data.
+Particle fields are detected as one-dimensional fields. The number of
+particles is set by the `number_of_particles` key in data.
 
-      Arguments:
+# Arguments
 
-      * `data::Dict`: A dict of Arrays or (Array, unit string) tuples.
-        The keys are the field names.
-      * `domain_dimensions::Array`: These are the domain dimensions of the grid
-      * `length_unit::String` (optional): Unit to use for lengths. Defaults to 1 cm.
-      * `bbox::Array` (optional): Size of computational domain in units specified by
-        `length_unit`. Defaults to a cubic unit-length domain.
-      * `nprocs::Integer` (optional): If greater than 1, will create this number of
-        subgrids out of data
-      * `sim_time::Real` (optional): The simulation time.
-      * `mass_unit` (optional): Unit to use for lengths. Defaults to 1 g.
-      * `time_unit` (optional): Unit to use for lengths. Defaults to 1 s.
-      * `velocity_unit` (optional): Unit to use for lengths. Defaults to 1 cm/s.
-      * `magnetic_unit` (optional): Unit to use for lengths. Defaults to 1 gauss.
-      * `periodicity::Tuple{Bool,Bool,Bool}` (optional): Determines whether the data
-        will be treated as periodic along each axis.
-      * `geometry::String` (optional): "cartesian", "cylindrical" or "polar"
+* `data::Dict`: A dict of Arrays or (Array, unit string) tuples. The keys are
+  the field names.
+* `domain_dimensions::Array`: These are the domain dimensions of the grid
+* `length_unit=nothing` (optional): Unit to use for lengths. Defaults to 1 cm.
+* `bbox=nothing` (optional): Size of computational domain in units specified by
+  `length_unit`. Defaults to a cubic unit-length domain.
+* `nprocs::Integer=1` (optional): If greater than 1, will create this number of
+  subgrids out of data
+* `sim_time::Real=0.0` (optional): The simulation time.
+* `mass_unit=nothing` (optional): Unit to use for lengths. Defaults to 1 g.
+* `time_unit=nothing` (optional): Unit to use for lengths. Defaults to 1 s.
+* `velocity_unit=nothing` (optional): Unit to use for lengths. Defaults to
+  1 cm/s.
+* `magnetic_unit=nothing` (optional): Unit to use for lengths. Defaults to 1
+  gauss.
+* `periodicity::Tuple{Bool,Bool,Bool}=(true, true, true)` (optional): Determines
+  whether the data will be treated as periodic along each axis.
+* `geometry::String="cartesian"` (optional): "cartesian", "cylindrical" or
+  "polar"
 
-      Examples:
-
-          julia> arr = rand(64,64,64)
-          julia> data = Dict()
-          julia> data["density"] = (arr, "g/cm^3")
-          julia> bbox = [-1.5 1.5; -1.5 1.5; -1.5 1.5]
-          julia> ds = YT.load_uniform_grid(data, [64,64,64]; length_unit="Mpc",
-                                           bbox=bbox, nprocs=64)
-      """ ->
+# Examples
+```julia
+julia> import YT
+julia> arr = rand(64,64,64)
+julia> data = Dict()
+julia> data["density"] = (arr, "g/cm^3")
+julia> bbox = [-1.5 1.5; -1.5 1.5; -1.5 1.5]
+julia> ds = YT.load_uniform_grid(data, [64,64,64]; length_unit="Mpc",
+                                 bbox=bbox, nprocs=64)
+```
+"""
 function load_uniform_grid(data::Dict{Any,Any}, domain_dimensions::Array;
                            length_unit=nothing, bbox=nothing,
                            nprocs=1, sim_time=0.0, mass_unit=nothing,

--- a/src/YT.jl
+++ b/src/YT.jl
@@ -149,22 +149,19 @@ particles is set by the `number_of_particles` key in data.
 * `data::Dict`: A dict of Arrays or (Array, unit string) tuples. The keys are
   the field names.
 * `domain_dimensions::Array`: These are the domain dimensions of the grid
-* `length_unit=nothing` (optional): Unit to use for lengths. Defaults to 1 cm.
-* `bbox=nothing` (optional): Size of computational domain in units specified by
+* `length_unit=nothing`: Unit to use for lengths. Defaults to 1 cm.
+* `bbox=nothing`: Size of computational domain in units specified by
   `length_unit`. Defaults to a cubic unit-length domain.
-* `nprocs::Integer=1` (optional): If greater than 1, will create this number of
-  subgrids out of data
-* `sim_time::Real=0.0` (optional): The simulation time.
-* `mass_unit=nothing` (optional): Unit to use for lengths. Defaults to 1 g.
-* `time_unit=nothing` (optional): Unit to use for lengths. Defaults to 1 s.
-* `velocity_unit=nothing` (optional): Unit to use for lengths. Defaults to
-  1 cm/s.
-* `magnetic_unit=nothing` (optional): Unit to use for lengths. Defaults to 1
-  gauss.
-* `periodicity::Tuple{Bool,Bool,Bool}=(true, true, true)` (optional): Determines
-  whether the data will be treated as periodic along each axis.
-* `geometry::String="cartesian"` (optional): "cartesian", "cylindrical" or
-  "polar"
+* `nprocs::Integer=1`: If greater than 1, will create this number of subgrids
+  out of data
+* `sim_time::Real=0.0`: The simulation time.
+* `mass_unit=nothing`: Unit to use for lengths. Defaults to 1 g.
+* `time_unit=nothing`: Unit to use for lengths. Defaults to 1 s.
+* `velocity_unit=nothing`: Unit to use for lengths. Defaults to 1 cm/s.
+* `magnetic_unit=nothing`: Unit to use for lengths. Defaults to 1 gauss.
+* `periodicity::Tuple{Bool,Bool,Bool}=(true, true, true)`: Determines whether
+  the data will be treated as periodic along each axis.
+* `geometry::String="cartesian"``: "cartesian", "cylindrical", or "polar"
 
 # Examples
 ```julia
@@ -193,58 +190,61 @@ function load_uniform_grid(data::Dict{Any,Any}, domain_dimensions::Array;
     return Dataset(ds)
 end
 
-@doc doc"""
-      Load a set of grids of data, of varying resolution. This comes with
-      several caveats:
+"""
+    load_amr_grids(data::Array, domain_dimensions::Array;
+                   bbox=nothing, sim_time=0.0, length_unit=nothing,
+                   mass_unit=nothing, time_unit=nothing,
+                   velocity_unit=nothing, magnetic_unit=nothing,
+                   periodicity=(true, true, true), geometry="cartesian",
+                   refine_by=2)
 
-      * Particles may be difficult to integrate.
-      * No consistency checks are performed on the index
+Load a set of grids of data, of varying resolution. This comes with
+several caveats:
 
-      Arguments:
+* Particles may be difficult to integrate.
+* No consistency checks are performed on the index
 
-      * `grid_data::Array`: This is an Array of Dicts. Each Dict must have entries
-        "left_edge", "right_edge", "dimensions", "level", and then any remaining
-        entries are assumed to be fields. Field entries must map to an Array. The
-        grid_data may also include a particle count. If no particle count is supplied,
-        the dataset is understood to contain no particles. The grid_data will be
-        modified in place and can't be assumed to be static.
-      * `domain_dimensions::Array`: These are the domain dimensions of the grid
-      * `field_units::Dict` (optional): A dictionary mapping string field names
-        to string unit specifications.  The field names must correspond to the
-        fields in grid_data.
-      * `length_unit::String` (optional): Unit to use for lengths. Defaults to 1 cm.
-      * `bbox::Array` (optional): Size of computational domain in units specified by
-        `length_unit`. Defaults to a cubic unit-length domain.
-      * `sim_time::Real` (optional): The simulation time.
-      * `mass_unit` (optional): Unit to use for lengths. Defaults to 1 g.
-      * `time_unit` (optional): Unit to use for lengths. Defaults to 1 s.
-      * `velocity_unit` (optional): Unit to use for lengths. Defaults to 1 cm/s.
-      * `magnetic_unit` (optional): Unit to use for lengths. Defaults to 1 gauss.
-      * `periodicity::Tuple{Bool,Bool,Bool}` (optional): Determines whether the data
-        will be treated as periodic along each axis.
-      * `geometry::String` (optional): "cartesian", "cylindrical" or "polar"
-      * `refine_by::Integer` (optional): Specifies the refinement ratio between
-        levels.  Defaults to 2.
+# Arguments
 
-      Examples:
+* `grid_data::Array`: This is an Array of Dicts. Each Dict must have entries
+  "left_edge", "right_edge", "dimensions", "level", and then any remaining
+  entries are assumed to be fields. Field entries must map to an Array. The
+  grid_data may also include a particle count. If no particle count is supplied,
+  the dataset is understood to contain no particles. The grid_data will be
+  modified in place and can't be assumed to be static.
+* `domain_dimensions::Array`: These are the domain dimensions of the grid
+* `length_unit=nothing`: Unit to use for lengths. Defaults to 1 cm.
+* `bbox=nothing`: Size of computational domain in units specified by
+  `length_unit`. Defaults to a cubic unit-length domain.
+* `sim_time::Real=0.0`: The simulation time.
+* `mass_unit=nothing`: Unit to use for lengths. Defaults to 1 g.
+* `time_unit=nothing`: Unit to use for lengths. Defaults to 1 s.
+* `velocity_unit=nothing`: Unit to use for lengths. Defaults to 1 cm/s.
+* `magnetic_unit=nothing`: Unit to use for lengths. Defaults to 1 gauss.
+* `periodicity::Tuple{Bool,Bool,Bool}=(true, true, true)`: Determines whether
+  the data will be treated as periodic along each axis.
+* `geometry::String="cartesian"`: "cartesian", "cylindrical", or "polar"
+* `refine_by::Integer=2`: Specifies the refinement ratio between levels.
 
-          julia> import YT
-          julia> grid_data = [
-                   Dict("left_edge"=>[0.0, 0.0, 0.0],
-                        "right_edge"=>[1.0, 1.0, 1.0],
-                        "level"=>0,
-                        "dimensions"=>[32, 32, 32]),
-                   Dict("left_edge"=>[0.25, 0.25, 0.25],
-                        "right_edge"=>[0.75, 0.75, 0.75],
-                        "level"=>1,
-                        "dimensions"=>[32, 32, 32])
-                 ]
-          julia> for g in grid_data
-                     g["density"] = (rand(g["dimensions"]...) * 2^g["level"], "g/cm^3")
-                 end
-          julia> ds = YT.load_amr_grids(grid_data, [32, 32, 32];
-                                        field_units=field_units)
-      """ ->
+# Examples
+```julia
+julia> import YT
+julia> grid_data = [
+         Dict("left_edge"=>[0.0, 0.0, 0.0],
+              "right_edge"=>[1.0, 1.0, 1.0],
+              "level"=>0,
+              "dimensions"=>[32, 32, 32]),
+         Dict("left_edge"=>[0.25, 0.25, 0.25],
+              "right_edge"=>[0.75, 0.75, 0.75],
+              "level"=>1,
+              "dimensions"=>[32, 32, 32])
+       ]
+julia> for g in grid_data
+           g["density"] = (rand(g["dimensions"]...) * 2^g["level"], "g/cm^3")
+       end
+julia> ds = YT.load_amr_grids(grid_data, [32, 32, 32])
+```
+"""
 function load_amr_grids(data::Array, domain_dimensions::Array;
                         bbox=nothing, sim_time=0.0, length_unit=nothing,
                         mass_unit=nothing, time_unit=nothing,
@@ -257,53 +257,60 @@ function load_amr_grids(data::Array, domain_dimensions::Array;
     return Dataset(ds)
 end
 
-@doc doc"""
-      Load a set of particles into yt.
+"""
+    load_particles(data::Dict{Any,Any}; length_unit=nothing, bbox=nothing,
+                   sim_time=0.0, mass_unit=nothing, time_unit=nothing,
+                   velocity_unit=nothing, magnetic_unit=nothing,
+                   periodicity=(true, true, true), n_ref=64,
+                   over_refine_factor=1, geometry="cartesian")
 
-      This should allow a collection of particle data to be loaded directly into
-      yt and analyzed as would any others.
+Load a set of particles into yt.
 
-      This will initialize an Octree of data. Note that fluid fields will not
-      work yet, or possibly ever.
+This should allow a collection of particle data to be loaded directly into
+yt and analyzed as would any others.
 
-      Arguments:
+This will initialize an Octree of data. Note that fluid fields will not
+work yet, or possibly ever.
 
-      * `data::Dict`: This is a dict of Arrays, where the keys are the field names.
-        Particle positions must be named "particle_position_x",
-        "particle_position_y", "particle_position_z".
-      * `length_unit::String` (optional): Unit to use for lengths. Defaults to 1 cm.
-      * `bbox::Array` (optional): Size of computational domain in units specified by
-        `length_unit`. Defaults to a cubic unit-length domain.
-      * `sim_time::Real` (optional): The simulation time.
-      * `mass_unit` (optional): Unit to use for lengths. Defaults to 1 g.
-      * `time_unit` (optional): Unit to use for lengths. Defaults to 1 s.
-      * `velocity_unit` (optional): Unit to use for lengths. Defaults to 1 cm/s.
-      * `magnetic_unit` (optional): Unit to use for lengths. Defaults to 1 gauss.
-      * `periodicity::Tuple{Bool,Bool,Bool}` (optional): Determines whether the data
-        will be treated as periodic along each axis.
-      * `geometry::String` (optional): "cartesian", "cylindrical" or "polar"
-      * `n_ref::Integer` (optional): The number of particles that result in refining an
-        oct used for indexing the particles.
+# Arguments
 
-      Examples:
+* `data::Dict`: This is a dict of Arrays, where the keys are the field names.
+  Particle positions must be named "particle_position_x", "particle_position_y",
+  "particle_position_z".
+* `length_unit=nothing`: Unit to use for lengths. Defaults to 1 cm.
+* `bbox=nothing`: Size of computational domain in units specified by
+  `length_unit`. Defaults to a cubic unit-length domain.
+* `sim_time::Real=0.0`: The simulation time.
+* `mass_unit=nothing`: Unit to use for lengths. Defaults to 1 g.
+* `time_unit=nothing`: Unit to use for lengths. Defaults to 1 s.
+* `velocity_unit=nothing`: Unit to use for lengths. Defaults to 1 cm/s.
+* `magnetic_unit=nothing`: Unit to use for lengths. Defaults to 1 gauss.
+* `periodicity::Tuple{Bool,Bool,Bool}=(true, true, true)`: Determines whether
+  the data will be treated as periodic along each axis.
+* `geometry::String="cartesian"`: "cartesian", "cylindrical", or "polar"
+* `n_ref::Integer=64` (optional): The number of particles that result in refining an
+oct used for indexing the particles.
 
-          julia> import YT
-          julia> n_particles = 5000000
-          julia> data = Dict()
-          julia> data["particle_position_x"] = 1.0e6*randn(n_particles)
-          julia> data["particle_position_y"] = 1.0e6*randn(n_particles)
-          julia> data["particle_position_z"] = 1.0e6*randn(n_particles)
-          julia> data["particle_mass"] = ones(n_particles)
-          julia> bbox = 1.1*[minimum(data["particle_position_x"])
-                             maximum(data["particle_position_x"]);
-                             minimum(data["particle_position_y"])
-                             maximum(data["particle_position_y"]);
-                             minimum(data["particle_position_z"])
-                             maximum(data["particle_position_z"])]
-          julia> ds = YT.load_particles(data, length_unit="pc",
-                                        mass_unit=(1e8, "Msun"),
-                                        n_ref=256, bbox=bbox)
-      """ ->
+# Examples
+```julia
+julia> import YT
+julia> n_particles = 5000000
+julia> data = Dict()
+julia> data["particle_position_x"] = 1.0e6*randn(n_particles)
+julia> data["particle_position_y"] = 1.0e6*randn(n_particles)
+julia> data["particle_position_z"] = 1.0e6*randn(n_particles)
+julia> data["particle_mass"] = ones(n_particles)
+julia> bbox = 1.1*[minimum(data["particle_position_x"])
+                   maximum(data["particle_position_x"]);
+                   minimum(data["particle_position_y"])
+                   maximum(data["particle_position_y"]);
+                   minimum(data["particle_position_z"])
+                   maximum(data["particle_position_z"])]
+julia> ds = YT.load_particles(data, length_unit="pc",
+                              mass_unit=(1e8, "Msun"),
+                              n_ref=256, bbox=bbox)
+```
+"""
 function load_particles(data::Dict{Any,Any}; length_unit=nothing, bbox=nothing,
                         sim_time=0.0, mass_unit=nothing, time_unit=nothing,
                         velocity_unit=nothing, magnetic_unit=nothing,

--- a/src/YT.jl
+++ b/src/YT.jl
@@ -53,7 +53,7 @@ import PyCall: @pyimport, PyError, pycall, PyObject, set!
 
 @pyimport yt
 
-min_version = v"3.2.2"
+min_version = v"3.3.1"
 
 yt_version = convert(VersionNumber, yt.__version__)
 if yt_version < min_version

--- a/src/YT.jl
+++ b/src/YT.jl
@@ -97,13 +97,13 @@ type YTConfig
     ytcfg::PyObject
 end
 
-function setindex!(ytcfg::YTConfig, value::ASCIIString, section::ASCIIString,
-                   param::ASCIIString)
+function setindex!(ytcfg::YTConfig, value::String, section::String,
+                   param::String)
     set!(ytcfg.ytcfg, (section,param), value)
 end
 
-function getindex(ytcfg::YTConfig, section::ASCIIString, param::ASCIIString)
-    pycall(ytcfg.ytcfg["get"], ASCIIString, section, param)
+function getindex(ytcfg::YTConfig, section::String, param::String)
+    pycall(ytcfg.ytcfg["get"], String, section, param)
 end
 
 show(ytcfg::YTConfig) = typeof(ytcfg)
@@ -111,8 +111,8 @@ show(ytcfg::YTConfig) = typeof(ytcfg)
 @doc doc""" The yt configuration object.""" ->
 ytcfg = YTConfig(ytconfig.ytcfg)
 
-@doc doc""" `load` a `Dataset` object from the file `fn::ASCIIString`.""" ->
-load(fn::ASCIIString; args...) = Dataset(ytconv.load(fn; args...))
+@doc doc""" `load` a `Dataset` object from the file `fn::String`.""" ->
+load(fn::String; args...) = Dataset(ytconv.load(fn; args...))
 
 # Stream datasets
 
@@ -135,7 +135,7 @@ load(fn::ASCIIString; args...) = Dataset(ytconv.load(fn; args...))
       * `data::Dict`: A dict of Arrays or (Array, unit string) tuples.
         The keys are the field names.
       * `domain_dimensions::Array`: These are the domain dimensions of the grid
-      * `length_unit::ASCIIString` (optional): Unit to use for lengths. Defaults to 1 cm.
+      * `length_unit::String` (optional): Unit to use for lengths. Defaults to 1 cm.
       * `bbox::Array` (optional): Size of computational domain in units specified by
         `length_unit`. Defaults to a cubic unit-length domain.
       * `nprocs::Integer` (optional): If greater than 1, will create this number of
@@ -147,7 +147,7 @@ load(fn::ASCIIString; args...) = Dataset(ytconv.load(fn; args...))
       * `magnetic_unit` (optional): Unit to use for lengths. Defaults to 1 gauss.
       * `periodicity::Tuple{Bool,Bool,Bool}` (optional): Determines whether the data
         will be treated as periodic along each axis.
-      * `geometry::ASCIIString` (optional): "cartesian", "cylindrical" or "polar"
+      * `geometry::String` (optional): "cartesian", "cylindrical" or "polar"
 
       Examples:
 
@@ -193,7 +193,7 @@ end
       * `field_units::Dict` (optional): A dictionary mapping string field names
         to string unit specifications.  The field names must correspond to the
         fields in grid_data.
-      * `length_unit::ASCIIString` (optional): Unit to use for lengths. Defaults to 1 cm.
+      * `length_unit::String` (optional): Unit to use for lengths. Defaults to 1 cm.
       * `bbox::Array` (optional): Size of computational domain in units specified by
         `length_unit`. Defaults to a cubic unit-length domain.
       * `sim_time::Real` (optional): The simulation time.
@@ -203,7 +203,7 @@ end
       * `magnetic_unit` (optional): Unit to use for lengths. Defaults to 1 gauss.
       * `periodicity::Tuple{Bool,Bool,Bool}` (optional): Determines whether the data
         will be treated as periodic along each axis.
-      * `geometry::ASCIIString` (optional): "cartesian", "cylindrical" or "polar"
+      * `geometry::String` (optional): "cartesian", "cylindrical" or "polar"
       * `refine_by::Integer` (optional): Specifies the refinement ratio between
         levels.  Defaults to 2.
 
@@ -252,7 +252,7 @@ end
       * `data::Dict`: This is a dict of Arrays, where the keys are the field names.
         Particle positions must be named "particle_position_x",
         "particle_position_y", "particle_position_z".
-      * `length_unit::ASCIIString` (optional): Unit to use for lengths. Defaults to 1 cm.
+      * `length_unit::String` (optional): Unit to use for lengths. Defaults to 1 cm.
       * `bbox::Array` (optional): Size of computational domain in units specified by
         `length_unit`. Defaults to a cubic unit-length domain.
       * `sim_time::Real` (optional): The simulation time.
@@ -262,7 +262,7 @@ end
       * `magnetic_unit` (optional): Unit to use for lengths. Defaults to 1 gauss.
       * `periodicity::Tuple{Bool,Bool,Bool}` (optional): Determines whether the data
         will be treated as periodic along each axis.
-      * `geometry::ASCIIString` (optional): "cartesian", "cylindrical" or "polar"
+      * `geometry::String` (optional): "cartesian", "cylindrical" or "polar"
       * `n_ref::Integer` (optional): The number of particles that result in refining an
         oct used for indexing the particles.
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -605,11 +605,13 @@ Write a `YTArray` to an HDF5 file.
 
 * `a::YTArray`: The `YTArray` to write to the file.
 * `filename::String`: The file to write to.
-* `dataset_name::String`: The name of the HDF5 dataset to write the data into.
-* `dataset_name::String`: The name of the HDF5 group to write the data into.
-* `info::Dict{String,Any}`: A dictionary of keys and values
-  to write to the file, associated with this array, that will be
-  stored in the dataset attributes.
+* `dataset_name::String=nothing`: The name of the HDF5 dataset to write the data
+  into.
+* `dataset_name::String=nothing`: The name of the HDF5 group to write the data
+  into.
+* `info::Dict{String,Any}=nothing`: A dictionary of keys and values to write to
+  the file, associated with this array, that will be stored in the dataset
+  attributes.
 
 # Examples
 ```julia
@@ -632,8 +634,10 @@ Read a `YTArray` from an HDF5 file.
 # Parameters
 
 * `filename::String`: The file to read from.
-* `dataset_name::String`: The name of the HDF5 dataset to read the data from.
-* `group_name::String`: The name of the HDF5 group to read the data from.
+* `dataset_name::String=nothing`: The name of the HDF5 dataset to read the data
+  from.
+* `group_name::String=nothing`: The name of the HDF5 group to read the data
+  from.
 
 # Examples
 ```julia

--- a/src/array.jl
+++ b/src/array.jl
@@ -78,7 +78,7 @@ type YTQuantity{T<:Real}
     units::YTUnit
 end
 
-function YTQuantity{T<:Real}(value::T, units::ASCIIString; registry=nothing)
+function YTQuantity{T<:Real}(value::T, units::String; registry=nothing)
     units = replace(units, "^", "**")
     unitary_quan = pycall(bare_quan, PyObject, 1.0, units, registry)
     yt_units = YTUnit(unitary_quan,
@@ -87,7 +87,7 @@ function YTQuantity{T<:Real}(value::T, units::ASCIIString; registry=nothing)
     YTQuantity{T}(value, yt_units)
 end
 
-function YTQuantity{T<:Real}(ds, value::T, units::ASCIIString)
+function YTQuantity{T<:Real}(ds, value::T, units::String)
     YTQuantity(value, units, registry=ds.ds["unit_registry"])
 end
 
@@ -95,7 +95,7 @@ function YTQuantity{T<:Real}(value::T, units::Sym; registry=nothing)
     YTQuantity(value, string(units); registry=registry)
 end
 
-YTQuantity(value::Bool, units::ASCIIString) = value
+YTQuantity(value::Bool, units::String) = value
 YTQuantity(value::Bool, units::Sym) = value
 YTQuantity(value::Bool, units::YTUnit) = value
 YTQuantity(value::Bool) = value
@@ -119,7 +119,7 @@ end
 YTArray{T<:Real}(value::Array{T}, units::YTUnit) = YTArray{T}(value, units)
 YTArray{T<:Real}(value::PyArray{T}, units::YTUnit) = YTArray{T}(value, units)
 
-function YTArray{T<:Real}(value::Array{T}, units::ASCIIString; registry=nothing)
+function YTArray{T<:Real}(value::Array{T}, units::String; registry=nothing)
     units = replace(units, "^", "**")
     unitary_quan = pycall(bare_quan, PyObject, 1.0, units, registry)
     yt_units = YTUnit(unitary_quan,
@@ -128,7 +128,7 @@ function YTArray{T<:Real}(value::Array{T}, units::ASCIIString; registry=nothing)
     YTArray{T}(value, yt_units)
 end
 
-function YTArray{T<:Real}(value::PyArray{T}, units::ASCIIString;
+function YTArray{T<:Real}(value::PyArray{T}, units::String;
                           registry=nothing)
     units = replace(units, "^", "**")
     unitary_quan = pycall(bare_quan, PyObject, 1.0, units, registry)
@@ -146,7 +146,7 @@ function YTArray(yt_array::PyObject)
     YTArray{eltype(value)}(value, yt_units)
 end
 
-function YTArray{T<:Real}(ds, value::Array{T}, units::ASCIIString)
+function YTArray{T<:Real}(ds, value::Array{T}, units::String)
     YTArray(value, units, registry=ds.ds["unit_registry"])
 end
 function YTArray{T<:Real}(value::Array{T}, units::Sym; registry=nothing)
@@ -155,10 +155,10 @@ end
 function YTArray{T<:Real}(value::PyArray{T}, units::Sym; registry=nothing)
     YTArray(value, string(units); registry=registry)
 end
-function YTArray(value::Real, units::ASCIIString; registry=nothing)
+function YTArray(value::Real, units::String; registry=nothing)
     YTQuantity(value, units; registry=registry)
 end
-function YTArray(ds, value::Real, units::ASCIIString)
+function YTArray(ds, value::Real, units::String)
     YTQuantity(value, units, registry=ds.ds["unit_registry"])
 end
 function YTArray(value::Real, units::Sym; registry=nothing)
@@ -166,7 +166,7 @@ function YTArray(value::Real, units::Sym; registry=nothing)
 end
 YTArray(value::Real, units::YTUnit) = YTQuantity(value, units)
 
-YTArray(value::BitArray, units::ASCIIString) = value
+YTArray(value::BitArray, units::String) = value
 YTArray(value::BitArray, units::Sym) = value
 YTArray(value::BitArray, units::YTUnit) = value
 
@@ -308,7 +308,7 @@ end
 # Unit conversions
 
 
-function in_units(a::YTObject, units::ASCIIString)
+function in_units(a::YTObject, units::String)
     units = replace(units, "^", "**")
     a.value*pycall(a.units.yt_unit["in_units"], YTQuantity, units)
 end
@@ -321,7 +321,7 @@ function in_mks(a::YTObject)
     a.value*pycall(a.units.yt_unit["in_mks"], YTQuantity)
 end
 
-function convert_to_units(a::YTObject, units::ASCIIString)
+function convert_to_units(a::YTObject, units::String)
     units = replace(units, "^",	"**")
     new_unit = pycall(a.units.yt_unit["in_units"], YTQuantity, units)
     a.value *= new_unit.value
@@ -591,10 +591,10 @@ quantile(a::YTArray,q::Number) = YTArray(quantile(a.value, q), a.units)
       Parameters:
 
       * `a::YTArray`: The `YTArray` to write to the file.
-      * `filename::ASCIIString`: The file to write to.
-      * `dataset_name::ASCIIString`: The name of the HDF5 dataset to
+      * `filename::String`: The file to write to.
+      * `dataset_name::String`: The name of the HDF5 dataset to
         write the data into.
-      * `info::Dict{ASCIIString,Any}`: A dictionary of keys and values
+      * `info::Dict{String,Any}`: A dictionary of keys and values
         to write to the file, associated with this array, that will be
         stored in the dataset attributes.
 
@@ -604,7 +604,7 @@ quantile(a::YTArray,q::Number) = YTArray(quantile(a.value, q), a.units)
           julia> a = YTArray(rand(10), "cm/s")
           juila> write_hdf5(a, "my_file.h5", dataset_name="velocity")
       """ ->
-function write_hdf5(a::YTArray, filename::ASCIIString; dataset_name=nothing,
+function write_hdf5(a::YTArray, filename::String; dataset_name=nothing,
                     info=nothing)
     arr = PyObject(a)
     arr[:write_hdf5](filename; dataset_name=dataset_name, info=info)
@@ -615,8 +615,8 @@ end
 
       Parameters:
 
-      * `filename::ASCIIString`: The file to read from.
-      * `dataset_name::ASCIIString`: The name of the HDF5 dataset to
+      * `filename::String`: The file to read from.
+      * `dataset_name::String`: The name of the HDF5 dataset to
         read the data from.
 
       Examples:
@@ -624,13 +624,13 @@ end
           julia> using YT
           juila> v = from_hdf5("my_file.h5", dataset_name="velocity")
       """ ->
-function from_hdf5(filename::ASCIIString; dataset_name=nothing)
+function from_hdf5(filename::String; dataset_name=nothing)
     YTArray(pycall(bare_array["from_hdf5"], PyObject, filename; dataset_name=dataset_name))
 end
 
 # Unit equivalencies
 
-function to_equivalent(a::YTObject, unit::ASCIIString, equiv::ASCIIString; args...)
+function to_equivalent(a::YTObject, unit::String, equiv::String; args...)
     arr = PyObject(a)
     unit = replace(unit, "^", "**")
     equ = pycall(arr["to_equivalent"], PyObject, unit, equiv; args...)
@@ -642,7 +642,7 @@ function list_equivalencies(a::YTObject)
     arr[:list_equivalencies]()
 end
 
-function has_equivalent(a::YTObject, equiv::ASCIIString)
+function has_equivalent(a::YTObject, equiv::String)
     arr = PyObject(a)
     arr[:has_equivalent](equiv)
 end

--- a/src/array.jl
+++ b/src/array.jl
@@ -269,16 +269,11 @@ pyslice(i::Array{Int,1}) = i-1
 getindex(a::YTArray, idxs::Indexes) = YTArray(getindex(a.value, idxs), a.units)
 getindex(a::PyArray, idxs::Indexes) = get(a.o, PyArray, pyslice(idxs))
 
-function setindex!(a::YTArray, x::Real, i::Integer)
-    a.value[i] = convert(eltype(a), x)
-end
-
 function setindex!(a::YTArray, x::Array, idxs::Indexes)
-    YTArray(setindex!(a.value, convert(typeof(a.value), x), idxs), a.units)
+    setindex!(a.value, convert(typeof(a.value), x), idxs)
 end
-
 function setindex!(a::YTArray, x::Real, idxs::Indexes)
-    YTArray(setindex!(a.value, convert(eltype(a), x), idxs), a.units)
+    setindex!(a.value, convert(eltype(a), x), idxs)
 end
 
 function getindex(a::YTArray, i::Indexes, j::Indexes)
@@ -290,6 +285,13 @@ function getindex(a::PyArray, i::Indexes, j::Indexes)
     get(a.o, PyArray, (ii,jj))
 end
 
+function setindex!(a::YTArray, x::Array, i::Indexes, j::Indexes)
+    setindex!(a.value, convert(typeof(a.value), x), i, j)
+end
+function setindex!(a::YTArray, x::Real, i::Indexes, j::Indexes)
+    setindex!(a.value, convert(eltype(a), x), i, j)
+end
+
 function getindex(a::YTArray, i::Indexes, j::Indexes, k::Indexes)
     YTArray(getindex(a.value, i, j, k), a.units)
 end
@@ -298,6 +300,13 @@ function getindex(a::PyArray, i::Indexes, j::Indexes, k::Indexes)
     jj = pyslice(j)
     kk = pyslice(k)
     get(a.o, PyArray, (ii,jj,kk))
+end
+
+function setindex!(a::YTArray, x::Array, i::Indexes, j::Indexes, k::Indexes)
+    setindex!(a.value, convert(typeof(a.value), x), i, j, k)
+end
+function setindex!(a::YTArray, x::Real, i::Indexes, j::Indexes, k::Indexes)
+    setindex!(a.value, convert(eltype(a), x), i, j, k)
 end
 
 # Unit conversions

--- a/src/array.jl
+++ b/src/array.jl
@@ -595,51 +595,79 @@ quantile(a::YTArray,q::Number) = YTArray(quantile(a.value, q), a.units)
 
 # To/from HDF5
 
-@doc doc"""
-      Write a `YTArray` to an HDF5 file.
+"""
+    write_hdf5(a::YTArray, filename::String; dataset_name=nothing,
+               info=nothing)
 
-      Parameters:
+Write a `YTArray` to an HDF5 file.
 
-      * `a::YTArray`: The `YTArray` to write to the file.
-      * `filename::String`: The file to write to.
-      * `dataset_name::String`: The name of the HDF5 dataset to
-        write the data into.
-      * `info::Dict{String,Any}`: A dictionary of keys and values
-        to write to the file, associated with this array, that will be
-        stored in the dataset attributes.
+# Parameters
 
-      Examples:
+* `a::YTArray`: The `YTArray` to write to the file.
+* `filename::String`: The file to write to.
+* `dataset_name::String`: The name of the HDF5 dataset to write the data into.
+* `dataset_name::String`: The name of the HDF5 group to write the data into.
+* `info::Dict{String,Any}`: A dictionary of keys and values
+  to write to the file, associated with this array, that will be
+  stored in the dataset attributes.
 
-          julia> using YT
-          julia> a = YTArray(rand(10), "cm/s")
-          juila> write_hdf5(a, "my_file.h5", dataset_name="velocity")
-      """ ->
+# Examples
+```julia
+julia> using YT
+julia> a = YTArray(rand(10), "cm/s")
+juila> write_hdf5(a, "my_file.h5", dataset_name="velocity")
+```
+"""
 function write_hdf5(a::YTArray, filename::String; dataset_name=nothing,
                     info=nothing)
     arr = PyObject(a)
     arr[:write_hdf5](filename; dataset_name=dataset_name, info=info)
 end
 
-@doc doc"""
-      Read a `YTArray` from an HDF5 file.
+"""
+    from_hdf5(filename::String; dataset_name=nothing, group_name=nothing)
 
-      Parameters:
+Read a `YTArray` from an HDF5 file.
 
-      * `filename::String`: The file to read from.
-      * `dataset_name::String`: The name of the HDF5 dataset to
-        read the data from.
+# Parameters
 
-      Examples:
+* `filename::String`: The file to read from.
+* `dataset_name::String`: The name of the HDF5 dataset to read the data from.
+* `group_name::String`: The name of the HDF5 group to read the data from.
 
-          julia> using YT
-          juila> v = from_hdf5("my_file.h5", dataset_name="velocity")
-      """ ->
-function from_hdf5(filename::String; dataset_name=nothing)
-    YTArray(pycall(bare_array["from_hdf5"], PyObject, filename; dataset_name=dataset_name))
+# Examples
+```julia
+julia> using YT
+juila> v = from_hdf5("my_file.h5", dataset_name="velocity", group_name="fields")
+```
+"""
+function from_hdf5(filename::String; dataset_name=nothing, group_name=nothing)
+    YTArray(pycall(bare_array["from_hdf5"], PyObject, filename;
+                   dataset_name=dataset_name, group_name=group_name))
 end
 
 # Unit equivalencies
 
+"""
+    to_equivalent(a::YTObject, unit::String, equiv::String; args...)
+
+Convert a `YTArray` or a `YTQuantity` to an equivalent quantity. For example,
+one may wish to convert a temperature to an equivalent energy kT, or a
+wavelength to a frequency, etc. For more information see the YT documentation.
+
+# Arguments
+
+* `a::YTObject`: A `YTArray` or `YTQuantity` to convert.
+* `unit::String`: The unit to convert to.
+* `equiv::String`: The equivalence to use.
+
+# Examples
+```julia
+julia> using YT
+julia> a = YTArray(rand(10), "keV")
+julia> to_equivalent(a, "K", "thermal")
+```
+"""
 function to_equivalent(a::YTObject, unit::String, equiv::String; args...)
     arr = PyObject(a)
     unit = replace(unit, "^", "**")
@@ -647,10 +675,21 @@ function to_equivalent(a::YTObject, unit::String, equiv::String; args...)
     array_or_quan(equ)
 end
 
+"""
+    list_equivalencies(a::YTObject)
+
+List the possible equivalencies for a given YTObject.
+"""
 function list_equivalencies(a::YTObject)
     arr = PyObject(a)
     arr[:list_equivalencies]()
 end
+
+"""
+    has_equivalent(a::YTObject, equiv::String)
+
+Check if a given `YTObject` has a given equivalence.
+"""
 
 function has_equivalent(a::YTObject, equiv::String)
     arr = PyObject(a)

--- a/src/array.jl
+++ b/src/array.jl
@@ -9,7 +9,7 @@ import Base: convert, copy, eltype, hypot, maximum, minimum, ndims,
              sum_kbn, gradient, dims2string, mean, std, stdm, var, varm,
              median, middle, midpoints, quantile, fill, start, next, done,
              +, -, *, /, \, ==, !=, >=, <=, >, <, ./, .\, .*, .==, .!=,
-             .>=, .<=, .>, .<, .^, ^, getindex, setindex!, isequal
+             .>=, .<=, .>, .<, .^, ^, getindex, setindex!, isequal, length
 
 import SymPy: Sym
 import PyCall: @pyimport, PyObject, pycall, PyArray, pybuiltin, PyAny
@@ -659,5 +659,7 @@ fill(a::YTQuantity, dims::Integer...) = YTArray(fill(a.value,dims), a.units)
 start(a::YTArray) = 1
 next(a::YTArray,i) = (a[i],i+1)
 done(a::YTArray,i) = (i > length(a))
+
+length(a::YTQuantity) = length(a.value)
 
 end

--- a/src/array.jl
+++ b/src/array.jl
@@ -499,12 +499,20 @@ end
 
 # Show
 
-summary(a::YTArray) = string(dims2string(size(a)), " YTArray ($(a.units)):")
+summary(a::YTArray) = string(dims2string(size(a)), " YTArray ($(a.units))")
 
-function showarray(io::IO, a::YTArray; kw...)
-    println(io, summary(a))
-    showarray(io, a.value; header=false, limit=true)
+function showarray(io::IO, a::YTArray, repr::Bool = true)
+    if !repr
+        println(io, "$(summary(a)):")
+    end
+    showarray(io, a.value, repr; header=false)
+    if repr
+        println(io, " $(a.units)")
+    end
 end
+
+show(io::IO, ::MIME"text/plain", X::YTArray) = showarray(io, X, false)
+show(io::IO, X::YTArray) = showarray(io, X)
 
 function print(io::IO, a::YTArray)
     print(io, "$(a.value) $(a.units)")
@@ -522,7 +530,6 @@ function print(q::YTQuantity)
     print(STDOUT,q)
 end
 
-display(a::YTArray) = show(STDOUT, a)
 show(io::IO, q::YTQuantity) = print(io, "$(q.value) $(q.units)")
 
 # Array methods

--- a/src/data_objects.jl
+++ b/src/data_objects.jl
@@ -173,7 +173,7 @@ A 0-dimensional object defined by a single point
   periodic its position will be corrected to lie inside the range [DLE, DRE)
   to ensure one and only one cell may match that point.
 * `field_parameters::Dict{String,Any}=nothing`: A dictionary of field parameters
-  than can be accessed by derived fields.
+  that can be accessed by derived fields.
 * `data_source::DataContainer=nothing`: Draw the selection from the provided
   data source rather than all data associated with the dataset
 
@@ -206,37 +206,40 @@ end
 
 # Region
 
-@doc doc"""
-      A 3D region of data with an arbitrary center.
+"""
+    Region(ds::Dataset, center::Center,
+           left_edge::Union{Array{Float64,1},YTArray},
+           right_edge::Union{Array{Float64,1},YTArray};
+           field_parameters=nothing, data_source=nothing)
 
-      Takes an array of three *left_edge* coordinates, three
-      *right_edge* coordinates, and a *center* that can be
-      anywhere in the domain. If the selected region extends
-      past the edges of the domain, no data will be found there,
-      though the object's `left_edge` or `right_edge` are not modified.
+A 3D region of data with an arbitrary center.
 
-      Arguments:
+Takes an array of three `left_edge` coordinates, three `right_edge` coordinates,
+and a `center` that can be anywhere in the domain. If the selected region
+extends past the edges of the domain, no data will be found there, though the
+object's `left_edge` or `right_edge` are not modified.
 
-      * `ds::Dataset`: The dataset to be used.
-      * `center::Center`: The center of the region
-      * `left_edge::Union{Array{Float64,1},YTArray}`: The left edge of
-        the region
-      * `right_edge::Union{Array{Float64,1},YTArray}`: The right edge of
-        the region
-      * `field_parameters::Dict{String,Any}` (optional): A dictionary of
-        field parameters than can be accessed by derived fields.
-      * `data_source::DataContainer` (optional): Draw the selection from the
-        provided data source rather than all data associated with the dataset
+# Arguments
 
-      Examples:
-          julia> import YT
-          julia> ds = YT.load("RedshiftOutput0005")
-          julia> left_edge = [0.1,0.1,0.1]
-          julia> right_edge = [0.6,0.6,0.6]
-          julia> center = "max"
-          julia> region = YT.Region(ds,center,left_edge,right_edge)
+* `ds::Dataset`: The dataset to be used.
+* `center::Center`: The center of the region
+* `left_edge::Union{Array{Float64,1},YTArray}`: The left edge of the region
+* `right_edge::Union{Array{Float64,1},YTArray}`: The right edge of the region
+* `field_parameters::Dict{String,Any}=nothing`: A dictionary of field parameters
+  that can be accessed by derived fields.
+* `data_source::DataContainer=nothing`: Draw the selection from the provided
+  data source rather than all data associated with the dataset.
 
-      """ ->
+# Examples
+```julia
+julia> import YT
+julia> ds = YT.load("RedshiftOutput0005")
+julia> left_edge = [0.1,0.1,0.1]
+julia> right_edge = [0.6,0.6,0.6]
+julia> center = "max"
+julia> region = YT.Region(ds,center,left_edge,right_edge)
+```
+"""
 type Region <: DataContainer
     cont::PyObject
     ds::Dataset
@@ -282,33 +285,38 @@ end
 
 # Disk
 
-@doc doc"""
-      By providing a `center`, a `normal`, a `radius` and a `height` we
-      can define a cylinder of any proportion. Only cells whose centers
-      are within the cylinder will be selected.
+"""
+    Disk(ds::Dataset, center::Center, normal::Array{Float64,1},
+         radius::Length, height::Length; field_parameters=nothing,
+         data_source=nothing)
 
-      Arguments:
+By providing a `center`, a `normal`, a `radius` and a `height` we
+can define a cylinder of any proportion. Only cells whose centers
+are within the cylinder will be selected.
 
-      * `ds::Dataset`: The dataset to be used.
-      * `center::Center`: Coordinate to which the normal, radius, and
-        height all reference
-      * `normal::Array{Float64,1}`: The normal vector defining the
-        direction of lengthwise part of the cylinder
-      * `radius::Length`: The radius of the cylinder
-      * `height::Length`: The distance from the midplane of the
-        cylinder to the top and bottom planes
-      * `field_parameters::Dict{String,Any}` (optional): A dictionary of
-        field parameters than can be accessed by derived fields.
-      * `data_source::DataContainer` (optional): Draw the selection from the
-        provided data source rather than all data associated with the dataset
+# Arguments
 
-      Examples:
+* `ds::Dataset`: The dataset to be used.
+* `center::Center`: Coordinate to which the normal, radius, and height all
+  reference
+* `normal::Array{Float64,1}`: The normal vector defining the direction of
+  lengthwise part of the cylinder
+* `radius::Length`: The radius of the cylinder
+* `height::Length`: The distance from the midplane of the cylinder to the top
+  and bottom planes
+* `field_parameters::Dict{String,Any}=nothing`: A dictionary of field parameters
+  that can be accessed by derived fields.
+* `data_source::DataContainer=nothing`: Draw the selection from the provided
+  data source rather than all data associated with the dataset
 
-          julia> import YT
-          julia> ds = YT.load("RedshiftOutput0005")
-          julia> c = [0.5,0.5,0.5]
-          julia> disk = Disk(ds, c, [1,0,0], (1, 'kpc'), (10, 'kpc'))
-      """ ->
+# Examples
+```julia
+julia> import YT
+julia> ds = YT.load("RedshiftOutput0005")
+julia> c = [0.5,0.5,0.5]
+julia> disk = Disk(ds, c, [1,0,0], (1, "kpc"), (10, "kpc"))
+```
+"""
 type Disk <: DataContainer
     cont::PyObject
     ds::Dataset
@@ -347,31 +355,33 @@ end
 
 # Ray
 
-@doc doc"""
-      This is an arbitrarily-aligned ray cast through the entire domain, at a
-      specific coordinate.
+"""
+    Ray(ds::Dataset, start_point::Array{Float64,1}, end_point::Array{Float64,1};
+        field_parameters=nothing, data_source=nothing)
 
-      The resulting arrays have their dimensionality reduced to one, and
-      an ordered list of points at an (x,y) tuple are available, as is the
-      `"t"` field, which corresponds to a unitless measurement along
-      the ray from start to end.
+This is an arbitrarily-aligned ray cast through the entire domain, at a specific
+coordinate. The resulting arrays have their dimensionality reduced to one, and
+an ordered list of points at an (x,y) tuple are available, as is the `"t"`
+field, which corresponds to a unitless measurement along the ray from start to
+end.
 
-      Arguments:
+# Arguments
 
-      * `ds::Dataset`: The dataset to be used.
-      * `start_point::Array{Float64,1}`: The place where the ray starts.
-      * `end_point::Array{Float64,1}`: The place where the ray ends.
-      * `field_parameters::Dict{String,Any}` (optional): A dictionary of
-        field parameters than can be accessed by derived fields.
-      * `data_source::DataContainer` (optional): Draw the selection from the
-        provided data source rather than all data associated with the dataset
+* `ds::Dataset`: The dataset to be used.
+* `start_point::Array{Float64,1}`: The place where the ray starts.
+* `end_point::Array{Float64,1}`: The place where the ray ends.
+* `field_parameters::Dict{String,Any}=nothing`: A dictionary of field parameters
+  that can be accessed by derived fields.
+* `data_source::DataContainer=nothing`: Draw the selection from the provided
+  data source rather than all data associated with the dataset.
 
-      Examples:
-
-          julia> import YT
-          julia> ds = YT.load("RedshiftOutput0005")
-          julia> ray = YT.Ray(ds, [0.2, 0.74, 0.11], [0.4, 0.91, 0.31])
-      """ ->
+# Examples
+```julia
+julia> import YT
+julia> ds = YT.load("RedshiftOutput0005")
+julia> ray = YT.Ray(ds, [0.2, 0.74, 0.11], [0.4, 0.91, 0.31])
+```
+"""
 type Ray <: DataContainer
     cont::PyObject
     ds::Dataset
@@ -397,33 +407,35 @@ end
 
 # OrthoRay
 
-@doc doc"""
-      This is an orthogonal ray cast through the entire domain, at a specific
-      coordinate.
+"""
+    OrthoRay(ds::Dataset, axis::Integer, coords::Tuple{Float64,Float64},
+             field_parameters=nothing, data_source=nothing)
 
-      The resulting arrays have their dimensionality reduced to one, and an
-      ordered list of points at an (x,y) tuple along `axis` are available.
+This is an orthogonal ray cast through the entire domain, at a specific
+coordinate. The resulting arrays have their dimensionality reduced to one, and
+an ordered list of points at an (x,y) tuple along `axis` are available.
 
-      Arguments:
+# Arguments
 
-      * `ds::Dataset`: The dataset to be used.
-      * `axis::Integer`: The axis along which to cast the ray. Can be 0, 1,
-        or 2 for x, y, z.
-      * `coords::(Float64,Float64)`: The (plane_x, plane_y) coordinates at
-        which to cast the ray. Note that this is in the plane coordinates:
-        so if you are casting along x, this will be (y,z). If you are casting
-        along y, this will be (x,z). If you are casting along z, this will be (x,y).
-      * `field_parameters::Dict{String,Any}` (optional): A dictionary of
-        field parameters than can be accessed by derived fields.
-      * `data_source::DataContainer` (optional): Draw the selection from the
-        provided data source rather than all data associated with the dataset
+* `ds::Dataset`: The dataset to be used.
+* `axis::Integer`: The axis along which to cast the ray. Can be 0, 1, or 2 for
+  x, y, z.
+* `coords::(Float64,Float64)`: The (plane_x, plane_y) coordinates at which to
+  cast the ray. Note that this is in the plane coordinates: so if you are
+  casting along x, this will be (y,z). If you are casting along y, this will be
+  (x,z). If you are casting along z, this will be (x,y).
+* `field_parameters::Dict{String,Any}=nothing`: A dictionary of field parameters
+  that can be accessed by derived fields.
+* `data_source::DataContainer=nothing`: Draw the selection from the provided
+  data source rather than all data associated with the dataset.
 
-      Examples:
-
-          julia> import YT
-          julia> ds = YT.load("RedshiftOutput0005")
-          julia> oray = YT.OrthoRay(ds, 0, (0.2, 0.74))
-      """ ->
+# Examples
+```julia
+julia> import YT
+julia> ds = YT.load("RedshiftOutput0005")
+julia> oray = YT.OrthoRay(ds, 0, (0.2, 0.74))
+```
+"""
 type OrthoRay <: DataContainer
     cont::PyObject
     ds::Dataset
@@ -447,35 +459,39 @@ end
 
 # Cutting
 
-@doc doc"""
-      This is a data object corresponding to an oblique slice through the
-      simulation domain.
+"""
+    Cutting(ds::Dataset, normal::Array{Float64,1}, center::Center;
+            north_vector=nothing, field_parameters=nothing, data_source=nothing)
 
-      A cutting plane is an oblique plane through the data, defined by a
-      normal vector and a coordinate. It attempts to guess a "north" vector,
-      which can be overridden, and then it pixelizes the appropriate data
-      onto the plane without interpolation.
+This is a data object corresponding to an oblique slice through the
+simulation domain.
 
-      Arguments:
+A cutting plane is an oblique plane through the data, defined by a
+normal vector and a coordinate. It attempts to guess a "north" vector,
+which can be overridden, and then it pixelizes the appropriate data
+onto the plane without interpolation.
 
-      * `ds::Dataset`: The dataset to be used.
-      * `normal::Array{Float64,1}`: The vector that defines the desired plane.
-        For instance, the angular momentum of a sphere.
-      * `center::Union(String,Array{Float64,1},YTArray)` : array_like
-        The center of the cutting plane, where the normal vector is anchored.
-      * `north_vector::Array{Float64,1}` (optional): An optional vector to describe the
-        north-facing direction in the resulting plane.
-      * `field_parameters::Dict{String,Any}` (optional): A dictionary of
-        field parameters than can be accessed by derived fields.
-      * `data_source::DataContainer` (optional): Draw the selection from the
-        provided data source rather than all data associated with the dataset
+# Arguments
 
-      Examples:
+* `ds::Dataset`: The dataset to be used.
+* `normal::Array{Float64,1}`: The vector that defines the desired plane. For
+  instance, the angular momentum of a sphere.
+* `center::Union(String,Array{Float64,1},YTArray)`: The center of the cutting
+  plane, where the normal vector is anchored.
+* `north_vector::Array{Float64,1}=nothing`: An optional vector to describe the
+  north-facing direction in the resulting plane.
+* `field_parameters::Dict{String,Any}=nothing`: A dictionary of field parameters
+  that can be accessed by derived fields.
+* `data_source::DataContainer=nothing`: Draw the selection from the provided
+  data source rather than all data associated with the dataset
 
-          julia> import YT
-          julia> ds = YT.load("RedshiftOutput0005")
-          juila> cp = YT.Cutting(ds, [0.1, 0.2, -0.9], [0.5, 0.42, 0.6])
-      """ ->
+# Examples
+```julia
+julia> import YT
+julia> ds = YT.load("RedshiftOutput0005")
+juila> cp = YT.Cutting(ds, [0.1, 0.2, -0.9], [0.5, 0.42, 0.6])
+```
+"""
 type Cutting <: DataContainer
     cont::PyObject
     ds::Dataset
@@ -505,48 +521,51 @@ end
 
 # Proj
 
-@doc doc"""
-      This is a data object corresponding to a line integral through the
-      simulation domain.
+"""
+    Proj(ds::Dataset, field, axis::Union{Integer,String}; weight_field=nothing,
+         center=nothing, field_parameters=nothing, data_source=nothing,
+         method="integrate")
 
-      `Proj` is a projection of a `field` along an `axis`. The field can
-      have an associated `weight_field`, in which case the values are
-      multiplied by a weight before being summed, and then divided by the
-      sum of that weight; the two fundamental modes of operating are direct
-      line integral (no weighting) and average along a line of sight
-      (weighting). Note that lines of sight are integrated at every projected
-      finest-level cell.
+This is a data object corresponding to a line integral through the
+simulation domain.
 
-      Arguments:
+`Proj` is a projection of a `field` along an `axis`. The field can
+have an associated `weight_field`, in which case the values are
+multiplied by a weight before being summed, and then divided by the
+sum of that weight; the two fundamental modes of operating are direct
+line integral (no weighting) and average along a line of sight
+(weighting). Note that lines of sight are integrated at every projected
+finest-level cell.
 
-      * `ds::Dataset`: The dataset to be used.
-      * `field::Field`: This is the field which will be "projected" along
-        the axis.
-      * `axis::Union(Integer,String)`: The axis along which to project.
-        Can be 0, 1, or 2, or "x", "y", or "z", for x, y, z.
-        The axis along which to slice.  Can be 0, 1, or 2 for x, y, z.
-      * `weight_field::Field`: If supplied, the field being projected will be
-        multiplied by this weight value before being integrated, and at the
-        conclusion of the projection the resultant values will be divided by
-        the projected `weight_field`.
-      * `center::Center` (optional): The `center` supplied to fields that use it.
-      * `data_source::DataContainer` (optional): If specified, this will be the data
-        source used for selecting regions to project.
-      * `method::String` (optional): The method of projection to be performed.
-        "integrate" : integration along the axis
-        "mip" : maximum intensity projection
-        "sum" : same as "integrate", except that we don't multiply by the path length
-        WARNING: The "sum" option should only be used for uniform resolution grid
-        datasets, as other datasets may result in unphysical images.
-      * `field_parameters::Dict{String,Any}` (optional): A dictionary of field
-        parameters than can be accessed by derived fields.
+# Arguments
 
-      Examples:
+* `ds::Dataset`: The dataset to be used.
+* `field::Field`: This is the field which will be "projected" along the axis.
+* `axis::Union(Integer,String)`: The axis along which to project. Can be 0, 1,
+  or 2, or "x", "y", or "z", for x, y, z.
+* `weight_field::Field=nothing`: If supplied, the field being projected will be
+  multiplied by this weight value before being integrated, and at the conclusion
+  of the projection the resultant values will be divided by the projected
+  `weight_field`.
+* `center::Center=nothing`: The `center` supplied to fields that use it.
+* `data_source::DataContainer=nothing`: If specified, this will be the data
+  source used for selecting regions to project.
+* `method::String="integrate"`: The method of projection to be performed.
+  "integrate": integration along the axis
+  "mip": maximum intensity projection
+  "sum": same as "integrate", except that we don't multiply by the path length
+  WARNING: The "sum" option should only be used for uniform resolution grid
+  datasets, as other datasets may result in unphysical images.
+* `field_parameters::Dict{String,Any}=nothing`: A dictionary of field parameters
+  that can be accessed by derived fields.
 
-          julia> import YT
-          julia> ds = YT.load("RedshiftOutput0005")
-          julia> prj = YT.Proj(ds, "density", 0)
-    """ ->
+# Examples
+```julia
+julia> import YT
+julia> ds = YT.load("RedshiftOutput0005")
+julia> prj = YT.Proj(ds, "density", 0)
+```
+"""
 type Proj <: DataContainer
     cont::PyObject
     ds::Dataset
@@ -573,34 +592,36 @@ end
 
 # Slice
 
-@doc doc"""
-      This is a data object corresponding to a slice through the simulation
-      domain.
+"""
+    Slice(ds::Dataset, axis::Union{Integer,String},
+          coord::Float64; center=nothing, field_parameters=nothing,
+          data_source=nothing)
 
-      The slice is an orthogonal slice through the data, taking all the
-      points at the finest resolution available and then indexing them.
+This is a data object corresponding to a slice through the simulation
+domain. The slice is an orthogonal slice through the data, taking all the
+points at the finest resolution available and then indexing them.
 
-      Arguments:
+# Arguments
 
-      * `ds::Dataset`: The dataset to be used.
-      * `axis::Union(Integer,String)`: The axis along which to slice.
-        Can be 0, 1, or 2, or "x", "y", or "z", for x, y, z.
-      * `coord::Float64`: The coordinate along the axis at which to
-        slice. This is in "domain" coordinates.
-      * `center::Array{Float64,1}` (optional): The 'center' supplied to fields that
-        use it. Note that this does not have to have `coord` as one value.
-      * `field_parameters::Dict{String,Any}` (optional): A dictionary of
-        field parameters than can be accessed by derived fields.
-      * `data_source::DataContainer` (optional): Draw the selection from the
-        provided data source rather than all data associated with the dataset
+* `ds::Dataset`: The dataset to be used.
+* `axis::Union(Integer,String)`: The axis along which to slice. Can be 0, 1, or
+  2, or "x", "y", or "z", for x, y, z.
+* `coord::Float64`: The coordinate along the axis at which to slice. This is in
+  "domain" coordinates.
+* `center::Array{Float64,1}=nothing`: The center supplied to fields that use it.
+  Note that this does not have to have `coord` as one value.
+* `field_parameters::Dict{String,Any}=nothing`: A dictionary of field parameters
+  that can be accessed by derived fields.
+* `data_source::DataContainer=nothing`: Draw the selection from the provided
+  data source rather than all data associated with the dataset.
 
-
-      Examples:
-
-          julia> import YT
-          julia> ds = YT.load("RedshiftOutput0005")
-          julia> slc = YT.Slice(ds, 0, 0.25)
-      """ ->
+# Examples
+```julia
+julia> import YT
+julia> ds = YT.load("RedshiftOutput0005")
+julia> slc = YT.Slice(ds, 0, 0.25)
+```
+"""
 type Slice <: DataContainer
     cont::PyObject
     ds::Dataset
@@ -701,26 +722,30 @@ end
 
 # Sphere
 
-@doc doc"""
-      A sphere of points defined by a `center` and a `radius`.
+"""
+    Sphere(ds::Dataset, center::Center, radius::Length;
+           field_parameters=nothing, data_source=nothing)
 
-      Arguments:
+A sphere of points defined by a `center` and a `radius`.
 
-      * `ds::Dataset`: The dataset to be used.
-      * `center::Center`: The center of the sphere.
-      * `radius::Length`: The radius of the sphere.
-      * `field_parameters::Dict{String,Any}` (optional): A dictionary of
-        field parameters than can be accessed by derived fields.
-      * `data_source::DataContainer` (optional): Draw the selection from the
-        provided data source rather than all data associated with the dataset
+# Arguments
 
-      Examples:
+* `ds::Dataset`: The dataset to be used.
+* `center::Center`: The center of the sphere.
+* `radius::Length`: The radius of the sphere.
+* `field_parameters::Dict{String,Any}=nothing`: A dictionary of field parameters
+  that can be accessed by derived fields.
+* `data_source::DataContainer=nothing`: Draw the selection from the provided
+  data source rather than all data associated with the dataset.
 
-          julia> import YT
-          julia> ds = YT.load("RedshiftOutput0005")
-          julia> c = [0.5,0.5,0.5]
-          julia> sp = YT.Sphere(ds, c, (1., "kpc"))
-      """ ->
+# Examples
+```julia
+julia> import YT
+julia> ds = YT.load("RedshiftOutput0005")
+julia> c = [0.5,0.5,0.5]
+julia> sp = YT.Sphere(ds, c, (1., "kpc"))
+```
+"""
 type Sphere <: DataContainer
     cont::PyObject
     ds::Dataset
@@ -754,27 +779,31 @@ end
 
 # CutRegion
 
-@doc doc"""
-      This is a data object designed to allow individuals to apply logical
-      operations to fields and filter as a result of those cuts.
+"""
+    CutRegion(dc::DataContainer, conditionals::Array{String,1},
+              field_parameters=nothing)
 
-      Arguments:
+This is a data object designed to allow individuals to apply logical operations
+to fields and filter as a result of those cuts.
 
-      * `dc::DataContainer`: The object to which cuts will be applied.
-      * `conditionals::Array{String,1}`: A list of conditionals that will
-        be evaluated. In the namespace available, these conditionals will have
-        access to `'obj'` which is a data object of unknown shape, and they must
-        generate a boolean array. For instance, `conditionals = ["obj['temperature'] < 1e3"]`
-      * `field_parameters::Dict{String,Any}` (optional): A dictionary of field
-        parameters than can be accessed by derived fields.
+Arguments:
 
-      Examples:
+* `dc::DataContainer`: The object to which cuts will be applied.
+* `conditionals::Array{String,1}`: A list of conditionals that will
+  be evaluated. In the namespace available, these conditionals will have
+  access to `"obj"` which is a data object of unknown shape, and they must
+  generate a boolean array. For instance, `conditionals = ["obj['temperature'] < 1e3"]`
+* `field_parameters::Dict{String,Any}=nothing`: A dictionary of field parameters
+  that can be accessed by derived fields.
 
-          julia> import YT
-          julia> ds = YT.load("RedshiftOutput0005")
-          julia> sp = YT.Sphere(ds, "max", (1.0, 'mpc'))
-          julia> cr = YT.CutRegion(sp, ["obj['temperature'] < 1e3"])
-      """ ->
+# Examples
+```julia
+julia> import YT
+julia> ds = YT.load("RedshiftOutput0005")
+julia> sp = YT.Sphere(ds, "max", (1.0, "Mpc"))
+julia> cr = YT.CutRegion(sp, ["obj['temperature'] < 1e3"])
+```
+""" ->
 type CutRegion <: DataContainer
     cont::PyObject
     ds::Dataset
@@ -827,29 +856,29 @@ end
 
 # CoveringGrid
 
-@doc doc"""
-      A 3D region with all data extracted to a single, specified
-      resolution.  Left edge should align with a cell boundary, but
-      defaults to the closest cell boundary.
+"""
+    CoveringGrid(ds::Dataset, level::Integer, left_edge::Array{Float64,1},
+                 dims::Array{Int,1}; field_parameters=nothing)
 
-      Arguments:
+A 3D region with all data extracted to a single, specified resolution. Left edge
+should align with a cell boundary, but defaults to the closest cell boundary.
 
-      * `ds::Dataset`: The dataset to be used.
-      * `level::Integer`: The resolution level data to which data
-        will be gridded.
-      * `left_edge::Array{Float64,1}`: The left edge of the region
-        to be extracted
-      * `dims::Array{Int,1}`: Number of cells along each axis of
-        the resulting `CoveringGrid`
-      * `field_parameters::Dict{String,Any}` (optional): A dictionary of field
-        parameters than can be accessed by derived fields.
+# Arguments
 
-      Examples:
+* `ds::Dataset`: The dataset to be used.
+* `level::Integer`: The resolution level data to which data will be gridded.
+* `left_edge::Array{Float64,1}`: The left edge of the region to be extracted.
+* `dims::Array{Int,1}`: Number of cells along each axis of the resulting grid.
+* `field_parameters::Dict{String,Any}=nothing`: A dictionary of field parameters
+  that can be accessed by derived fields.
 
-          julia> import YT
-          julia> ds = YT.load("RedshiftOutput0005")
-          julia> cube = CoveringGrid(ds, 2, [0.0, 0.0, 0.0], [128, 128, 128])
-      """ ->
+# Examples
+```julia
+julia> import YT
+julia> ds = YT.load("RedshiftOutput0005")
+julia> cube = CoveringGrid(ds, 2, [0.0, 0.0, 0.0], [128, 128, 128])
+```
+"""
 type CoveringGrid <: DataContainer
     cont::PyObject
     ds::Dataset

--- a/src/data_objects.jl
+++ b/src/data_objects.jl
@@ -6,10 +6,10 @@ import Base: size, show, showarray, display, showerror, start, next, done,
 import ..array: YTArray, YTQuantity, in_units, array_or_quan
 import ..fixed_resolution: FixedResolutionBuffer
 
-Center = Union{ASCIIString,Array{Float64,1},YTArray,
-               Tuple{ASCIIString,ASCIIString}}
-Length = Union{Float64,Tuple{Float64,ASCIIString},YTQuantity}
-Field  = Union{ASCIIString,Tuple{ASCIIString,ASCIIString}}
+Center = Union{String,Array{Float64,1},YTArray,
+               Tuple{String,String}}
+Length = Union{Float64,Tuple{Float64,String},YTQuantity}
+Field  = Union{String,Tuple{String,String}}
 
 # Dataset
 
@@ -116,7 +116,7 @@ end
       Arguments:
 
       * `ds::Dataset`: The dataset to be used.
-      * `field_parameters::Dict{ASCIIString,Any}` (optional): A dictionary of
+      * `field_parameters::Dict{String,Any}` (optional): A dictionary of
         field parameters than can be accessed by derived fields.
       * `data_source::DataContainer` (optional): Draw the selection from the
         provided data source rather than all data associated with the dataset
@@ -155,7 +155,7 @@ end
       * `p::Array{Float64,1}`: A point defined within the domain. If the domain is periodic
         its position will be corrected to lie inside the range [DLE,DRE) to ensure
         one and only one cell may match that point.
-      * `field_parameters::Dict{ASCIIString,Any}` (optional): A dictionary of
+      * `field_parameters::Dict{String,Any}` (optional): A dictionary of
         field parameters than can be accessed by derived fields.
       * `data_source::DataContainer` (optional): Draw the selection from the
         provided data source rather than all data associated with the dataset
@@ -204,7 +204,7 @@ end
         the region
       * `right_edge::Union{Array{Float64,1},YTArray}`: The right edge of
         the region
-      * `field_parameters::Dict{ASCIIString,Any}` (optional): A dictionary of
+      * `field_parameters::Dict{String,Any}` (optional): A dictionary of
         field parameters than can be accessed by derived fields.
       * `data_source::DataContainer` (optional): Draw the selection from the
         provided data source rather than all data associated with the dataset
@@ -278,7 +278,7 @@ end
       * `radius::Length`: The radius of the cylinder
       * `height::Length`: The distance from the midplane of the
         cylinder to the top and bottom planes
-      * `field_parameters::Dict{ASCIIString,Any}` (optional): A dictionary of
+      * `field_parameters::Dict{String,Any}` (optional): A dictionary of
         field parameters than can be accessed by derived fields.
       * `data_source::DataContainer` (optional): Draw the selection from the
         provided data source rather than all data associated with the dataset
@@ -342,7 +342,7 @@ end
       * `ds::Dataset`: The dataset to be used.
       * `start_point::Array{Float64,1}`: The place where the ray starts.
       * `end_point::Array{Float64,1}`: The place where the ray ends.
-      * `field_parameters::Dict{ASCIIString,Any}` (optional): A dictionary of
+      * `field_parameters::Dict{String,Any}` (optional): A dictionary of
         field parameters than can be accessed by derived fields.
       * `data_source::DataContainer` (optional): Draw the selection from the
         provided data source rather than all data associated with the dataset
@@ -393,7 +393,7 @@ end
         which to cast the ray. Note that this is in the plane coordinates:
         so if you are casting along x, this will be (y,z). If you are casting
         along y, this will be (x,z). If you are casting along z, this will be (x,y).
-      * `field_parameters::Dict{ASCIIString,Any}` (optional): A dictionary of
+      * `field_parameters::Dict{String,Any}` (optional): A dictionary of
         field parameters than can be accessed by derived fields.
       * `data_source::DataContainer` (optional): Draw the selection from the
         provided data source rather than all data associated with the dataset
@@ -441,11 +441,11 @@ end
       * `ds::Dataset`: The dataset to be used.
       * `normal::Array{Float64,1}`: The vector that defines the desired plane.
         For instance, the angular momentum of a sphere.
-      * `center::Union(ASCIIString,Array{Float64,1},YTArray)` : array_like
+      * `center::Union(String,Array{Float64,1},YTArray)` : array_like
         The center of the cutting plane, where the normal vector is anchored.
       * `north_vector::Array{Float64,1}` (optional): An optional vector to describe the
         north-facing direction in the resulting plane.
-      * `field_parameters::Dict{ASCIIString,Any}` (optional): A dictionary of
+      * `field_parameters::Dict{String,Any}` (optional): A dictionary of
         field parameters than can be accessed by derived fields.
       * `data_source::DataContainer` (optional): Draw the selection from the
         provided data source rather than all data associated with the dataset
@@ -502,7 +502,7 @@ end
       * `ds::Dataset`: The dataset to be used.
       * `field::Field`: This is the field which will be "projected" along
         the axis.
-      * `axis::Union(Integer,ASCIIString)`: The axis along which to project.
+      * `axis::Union(Integer,String)`: The axis along which to project.
         Can be 0, 1, or 2, or "x", "y", or "z", for x, y, z.
         The axis along which to slice.  Can be 0, 1, or 2 for x, y, z.
       * `weight_field::Field`: If supplied, the field being projected will be
@@ -512,13 +512,13 @@ end
       * `center::Center` (optional): The `center` supplied to fields that use it.
       * `data_source::DataContainer` (optional): If specified, this will be the data
         source used for selecting regions to project.
-      * `method::ASCIIString` (optional): The method of projection to be performed.
+      * `method::String` (optional): The method of projection to be performed.
         "integrate" : integration along the axis
         "mip" : maximum intensity projection
         "sum" : same as "integrate", except that we don't multiply by the path length
         WARNING: The "sum" option should only be used for uniform resolution grid
         datasets, as other datasets may result in unphysical images.
-      * `field_parameters::Dict{ASCIIString,Any}` (optional): A dictionary of field
+      * `field_parameters::Dict{String,Any}` (optional): A dictionary of field
         parameters than can be accessed by derived fields.
 
       Examples:
@@ -534,7 +534,7 @@ type Proj <: DataContainer
     axis::Integer
     weight_field
     field_dict::Dict
-    function Proj(ds::Dataset, field, axis::Union{Integer,ASCIIString};
+    function Proj(ds::Dataset, field, axis::Union{Integer,String};
                   weight_field=nothing, center=nothing,
                   field_parameters=nothing, data_source=nothing,
                   method="integrate")
@@ -563,13 +563,13 @@ end
       Arguments:
 
       * `ds::Dataset`: The dataset to be used.
-      * `axis::Union(Integer,ASCIIString)`: The axis along which to slice.
+      * `axis::Union(Integer,String)`: The axis along which to slice.
         Can be 0, 1, or 2, or "x", "y", or "z", for x, y, z.
       * `coord::Float64`: The coordinate along the axis at which to
         slice. This is in "domain" coordinates.
       * `center::Array{Float64,1}` (optional): The 'center' supplied to fields that
         use it. Note that this does not have to have `coord` as one value.
-      * `field_parameters::Dict{ASCIIString,Any}` (optional): A dictionary of
+      * `field_parameters::Dict{String,Any}` (optional): A dictionary of
         field parameters than can be accessed by derived fields.
       * `data_source::DataContainer` (optional): Draw the selection from the
         provided data source rather than all data associated with the dataset
@@ -587,7 +587,7 @@ type Slice <: DataContainer
     axis::Integer
     coord::Float64
     field_dict::Dict
-    function Slice(ds::Dataset, axis::Union{Integer,ASCIIString},
+    function Slice(ds::Dataset, axis::Union{Integer,String},
                    coord::Float64; center=nothing,
                    field_parameters=nothing,
                    data_source=nothing)
@@ -662,7 +662,7 @@ end
       * `ds::Dataset`: The dataset to be used.
       * `center::Center`: The center of the sphere.
       * `radius::Length`: The radius of the sphere.
-      * `field_parameters::Dict{ASCIIString,Any}` (optional): A dictionary of
+      * `field_parameters::Dict{String,Any}` (optional): A dictionary of
         field parameters than can be accessed by derived fields.
       * `data_source::DataContainer` (optional): Draw the selection from the
         provided data source rather than all data associated with the dataset
@@ -714,11 +714,11 @@ end
       Arguments:
 
       * `dc::DataContainer`: The object to which cuts will be applied.
-      * `conditionals::Array{ASCIIString,1}`: A list of conditionals that will
+      * `conditionals::Array{String,1}`: A list of conditionals that will
         be evaluated. In the namespace available, these conditionals will have
         access to `'obj'` which is a data object of unknown shape, and they must
         generate a boolean array. For instance, `conditionals = ["obj['temperature'] < 1e3"]`
-      * `field_parameters::Dict{ASCIIString,Any}` (optional): A dictionary of field
+      * `field_parameters::Dict{String,Any}` (optional): A dictionary of field
         parameters than can be accessed by derived fields.
 
       Examples:
@@ -731,9 +731,9 @@ end
 type CutRegion <: DataContainer
     cont::PyObject
     ds::Dataset
-    conditionals::Array{ASCIIString,1}
+    conditionals::Array{String,1}
     field_dict::Dict
-    function CutRegion(dc::DataContainer, conditionals::Array{ASCIIString,1},
+    function CutRegion(dc::DataContainer, conditionals::Array{String,1},
                        field_parameters=nothing)
         field_parameters = parse_fps(field_parameters)
         cut_reg = dc.cont[:cut_region](conditionals,
@@ -797,7 +797,7 @@ end
         to be extracted
       * `dims::Array{Int,1}`: Number of cells along each axis of
         the resulting `CoveringGrid`
-      * `field_parameters::Dict{ASCIIString,Any}` (optional): A dictionary of field
+      * `field_parameters::Dict{String,Any}` (optional): A dictionary of field
         parameters than can be accessed by derived fields.
 
       Examples:
@@ -835,7 +835,7 @@ end
 
       * `dc::DataContainer`: The data container object to set the
         parameter for.
-      * `key::ASCIIString`: The name of the parameter to set.
+      * `key::String`: The name of the parameter to set.
       * `value::Any`: The value of the parameter.
 
       Examples:
@@ -846,7 +846,7 @@ end
           julia> set_field_parameter(sp, "mu", 0.592)
 
       """ ->
-function set_field_parameter(dc::DataContainer, key::ASCIIString, value)
+function set_field_parameter(dc::DataContainer, key::String, value)
     v = PyObject(value)
     dc.cont[:set_field_parameter](key, v)
 end
@@ -858,7 +858,7 @@ end
 
       * `dc::DataContainer`: The data container object to check for
         a parameter.
-      * `key::ASCIIString`: The name of the parameter to check.
+      * `key::String`: The name of the parameter to check.
 
       Examples:
 
@@ -867,7 +867,7 @@ end
           julia> sp = YT.Sphere(ds, "c", (200.,"kpc"))
           julia> has_field_parameter(sp, "center")
       """ ->
-function has_field_parameter(dc::DataContainer, key::ASCIIString)
+function has_field_parameter(dc::DataContainer, key::String)
     dc.cont[:has_field_parameter](key)
 end
 
@@ -878,7 +878,7 @@ end
 
       * `dc::DataContainer`: The data container object to get the
         parameter from.
-      * `key::ASCIIString`: The name of the parameter to get.
+      * `key::String`: The name of the parameter to get.
 
       Examples:
 
@@ -888,7 +888,7 @@ end
           julia> ctr = get_field_parameter(sp, "center")
 
       """ ->
-function get_field_parameter(dc::DataContainer, key::ASCIIString)
+function get_field_parameter(dc::DataContainer, key::String)
     v = pycall(dc.cont["get_field_parameter"], PyObject, key)
     if contains(pystring(v), "YTArray") || contains(pystring(v), "YTQuantity")
         v = YTArray(v)
@@ -931,8 +931,8 @@ function getindex(dc::DataContainer, field::Field)
     return dc.field_dict[field]
 end
 
-getindex(dc::DataContainer, ftype::ASCIIString,
-         fname::ASCIIString) = getindex(dc, (ftype, fname))
+getindex(dc::DataContainer, ftype::String,
+         fname::String) = getindex(dc, (ftype, fname))
 
 function getindex(grids::Grids, i::Integer)
     if !haskey(grids.grid_dict, i)

--- a/src/data_objects.jl
+++ b/src/data_objects.jl
@@ -803,7 +803,7 @@ julia> ds = YT.load("RedshiftOutput0005")
 julia> sp = YT.Sphere(ds, "max", (1.0, "Mpc"))
 julia> cr = YT.CutRegion(sp, ["obj['temperature'] < 1e3"])
 ```
-""" ->
+"""
 type CutRegion <: DataContainer
     cont::PyObject
     ds::Dataset

--- a/src/data_objects.jl
+++ b/src/data_objects.jl
@@ -44,51 +44,61 @@ type Dataset
     end
 end
 
-@doc doc"""
-      Get the smallest cell size or SPH smoothing length of
-      a `ds::Dataset`.
-      """ ->
+"""
+    get_smallest_dx(ds::Dataset)
+
+Get the smallest cell size or SPH smoothing length of
+a `Dataset`.
+"""
 function get_smallest_dx(ds::Dataset)
     pycall(ds.ds[:index]["get_smallest_dx"], YTArray)[1]
 end
 
-@doc doc"""
-      Print important stats on a `ds::Dataset`.
-      """ ->
+"""
+    print_stats(ds::Dataset)
+
+Print important stats on a `Dataset`.
+"""
 function print_stats(ds::Dataset)
     ds.ds[:print_stats]()
 end
 
-@doc doc"""
-      For a `ds::Dataset`, find the value and the location of the
-      minimum of a `field::Field`.
-      """ ->
+"""
+     find_min(ds::Dataset, field::Field)
+
+For a `Dataset`, find the value and the location of the minimum of a field.
+"""
 function find_min(ds::Dataset, field::Field)
     a = pycall(ds.ds["find_min"], PyObject, field)
     v, c = PyVector{PyObject}(a)
     YTQuantity(v), YTArray(c)
 end
 
-@doc doc"""
-      For a `ds::Dataset`, find the value and the location of the
-      maximum of a `field::Field`.
-      """ ->
+"""
+     find_max(ds::Dataset, field::Field)
+
+For a `Dataset`, find the value and the location of the maximum of a field.
+"""
 function find_max(ds::Dataset, field::Field)
     a = pycall(ds.ds["find_max"], PyObject, field)
     v, c = PyVector{PyObject}(a)
     YTQuantity(v), YTArray(c)
 end
 
-@doc doc"""
-      Get the field list of a `ds::Dataset`.
-      """ ->
+"""
+    get_field_list(ds::Dataset)
+
+Get the field list of a `Dataset`.
+"""
 function get_field_list(ds::Dataset)
     ds.ds[:field_list]
 end
 
-@doc doc"""
-      Get all of the derived fields of a `ds::Dataset`.
-      """ ->
+"""
+    get_derived_field_list(ds::Dataset)
+
+Get all of the derived fields of a `Dataset`.
+"""
 function get_derived_field_list(ds::Dataset)
     ds.ds[:derived_field_list]
 end
@@ -110,23 +120,27 @@ end
 
 # AllData
 
-@doc doc"""
-      An object representing all of the data in the domain.
+"""
+    AllData(ds::Dataset; field_parameters=nothing,
+            data_source=nothing)
 
-      Arguments:
+An object representing all of the data in the domain.
 
-      * `ds::Dataset`: The dataset to be used.
-      * `field_parameters::Dict{String,Any}` (optional): A dictionary of
-        field parameters than can be accessed by derived fields.
-      * `data_source::DataContainer` (optional): Draw the selection from the
-        provided data source rather than all data associated with the dataset
+# Arguments
 
-      Examples:
+* `ds::Dataset`: The dataset to be used.
+* `field_parameters::Dict{String,Any}=nothing`: A dictionary of field parameters
+  that can be accessed by derived fields.
+* `data_source::DataContainer=nothing`: Draw the selection from the provided
+  data source rather than all data associated with the dataset
 
-          julia> import YT
-          julia> ds = YT.load("RedshiftOutput0005")
-          julia> dd = YT.AllData(ds)
-      """ ->
+# Examples
+```julia
+julia> import YT
+julia> ds = YT.load("RedshiftOutput0005")
+julia> dd = YT.AllData(ds)
+```
+"""
 type AllData <: DataContainer
     cont::PyObject
     ds::Dataset
@@ -146,27 +160,31 @@ end
 
 # Point
 
-@doc doc"""
-      A 0-dimensional object defined by a single point
+"""
+    Point(ds::Dataset, coord::Array{Float64,1}; field_parameters=nothing,
+          data_source=nothing)
 
-      Arguments:
+A 0-dimensional object defined by a single point
 
-      * `ds::Dataset`: The dataset to be used.
-      * `p::Array{Float64,1}`: A point defined within the domain. If the domain is periodic
-        its position will be corrected to lie inside the range [DLE,DRE) to ensure
-        one and only one cell may match that point.
-      * `field_parameters::Dict{String,Any}` (optional): A dictionary of
-        field parameters than can be accessed by derived fields.
-      * `data_source::DataContainer` (optional): Draw the selection from the
-        provided data source rather than all data associated with the dataset
+# Arguments
 
-      Examples:
+* `ds::Dataset`: The dataset to be used.
+* `p::Array{Float64,1}`: A point defined within the domain. If the domain is
+  periodic its position will be corrected to lie inside the range [DLE, DRE)
+  to ensure one and only one cell may match that point.
+* `field_parameters::Dict{String,Any}=nothing`: A dictionary of field parameters
+  than can be accessed by derived fields.
+* `data_source::DataContainer=nothing`: Draw the selection from the provided
+  data source rather than all data associated with the dataset
 
-          julia> import YT
-          julia> ds = YT.load("RedshiftOutput0005")
-          julia> c = [0.5,0.5,0.5]
-          julia> point = YT.Point(ds,c)
-      """ ->
+# Examples
+```julia
+julia> import YT
+julia> ds = YT.load("RedshiftOutput0005")
+julia> c = [0.5,0.5,0.5]
+julia> point = YT.Point(ds,c)
+```
+"""
 type Point <: DataContainer
     cont::PyObject
     ds::Dataset
@@ -187,6 +205,7 @@ type Point <: DataContainer
 end
 
 # Region
+
 @doc doc"""
       A 3D region of data with an arbitrary center.
 
@@ -377,6 +396,7 @@ type Ray <: DataContainer
 end
 
 # OrthoRay
+
 @doc doc"""
       This is an orthogonal ray cast through the entire domain, at a specific
       coordinate.
@@ -604,27 +624,31 @@ type Slice <: DataContainer
     end
 end
 
-@doc doc"""
-      Create a FixedResolutionBuffer from a slice or projection.
+"""
+    to_frb(cont::Union{Slice,Proj}, width::Length,
+           nx::Union{Integer,Tuple{Integer,Integer}}; center=nothing,
+           height=nothing, periodic=false)
 
-      Arguments:
+Create a `FixedResolutionBuffer` from a slice or projection.
 
-      * `cont::Union{Slice,Proj}` or `cont::Cutting`: A Slice, Proj, or Cutting DataContainer.
-      * `width::Length`: The width of the FRB.
-      * `nx::Union{Integer,Tuple{Integer,Integer}}`: Either an integer or a 2-tuple of
-        integers, corresponding to the dimensions of the image.
-      * `center::Center` (optional): The center of the FRB. If not specified,
-        defaults to the center of the current object. Not available if `cont` is a
-        `Cutting.`
-      * `height::Length` (optional): The height of the FRB. If not specified,
-        defaults to the `width`.
-      * `periodic::Bool` (optional): Is the FRB periodic? Default `false`.
+# Arguments
 
-      Examples:
+* `cont::Union{Slice,Proj}`: A Slice or Proj DataContainer.
+* `width::Length`: The width of the FRB.
+* `nx::Union{Integer,Tuple{Integer,Integer}}`: Either an integer or a 2-tuple of
+  integers, corresponding to the dimensions of the image.
+* `center::Center=nothing`: The center of the FRB. If not specified, defaults to
+  the center of the current object.
+* `height::Length=nothing`: The height of the FRB. If not specified, defaults to
+  the `width`.
+* `periodic::Bool=false`: Is the FRB periodic?
 
-          julia> slc = Slice(ds, "z", 0.0)
-          julia> frb = to_frb(slc, (500.,"kpc"), 800)
-      """ ->
+# Examples
+```julia
+julia> slc = Slice(ds, "z", 0.0)
+julia> frb = to_frb(slc, (500.,"kpc"), 800)
+```
+"""
 function to_frb(cont::Union{Slice,Proj}, width::Length,
                 nx::Union{Integer,Tuple{Integer,Integer}}; center=nothing,
                 height=nothing, periodic=false)
@@ -639,6 +663,29 @@ function to_frb(cont::Union{Slice,Proj}, width::Length,
                                                       periodic=periodic))
 end
 
+"""
+    to_frb(cont::Cutting, width::Length,
+           nx::Union{Integer,Tuple{Integer,Integer}};
+           height=nothing, periodic=false)
+
+Create a `FixedResolutionBuffer` from a cutting plane.
+
+# Arguments
+
+* `cont::Union{Slice,Proj}`: A Cutting DataContainer.
+* `width::Length`: The width of the FRB.
+* `nx::Union{Integer,Tuple{Integer,Integer}}`: Either an integer or a 2-tuple of
+  integers, corresponding to the dimensions of the image.
+* `height::Length=nothing`: The height of the FRB. If not specified, defaults to
+  the `width`.
+* `periodic::Bool=false`: Is the FRB periodic?
+
+# Examples
+```julia
+julia> cp = YT.Cutting(ds, [0.1, 0.2, -0.9], [0.5, 0.42, 0.6])
+julia> frb = to_frb(cp, (500.,"kpc"), 800)
+```
+"""
 function to_frb(cont::Cutting, width::Length,
                 nx::Union{Integer,Tuple{Integer,Integer}};
                 height=nothing, periodic=false)
@@ -744,9 +791,6 @@ end
 
 # Grids
 
-@doc doc"""
-      Return an `Array` of grids associated with `ds::Dataset`.
-      """ ->
 type Grids <: AbstractArray
     grids::Array
     grid_dict::Dict
@@ -828,66 +872,70 @@ end
 
 # Field parameters
 
-@doc doc"""
-      Set the value of a field parameter in a data container.
+"""
+    set_field_parameter(dc::DataContainer, key::String, value)
 
-      Arguments:
+Set the value of a field parameter in a data container.
 
-      * `dc::DataContainer`: The data container object to set the
-        parameter for.
-      * `key::String`: The name of the parameter to set.
-      * `value::Any`: The value of the parameter.
+# Arguments
 
-      Examples:
+* `dc::DataContainer`: The data container object to set the parameter for.
+* `key::String`: The name of the parameter to set.
+* `value::Any`: The value of the parameter.
 
-          julia> import YT
-          julia> ds = YT.load("GasSloshing/sloshing_nomag2_hdf5_plt_cnt_0100")
-          julia> sp = YT.Sphere(ds, "c", (200.,"kpc"))
-          julia> set_field_parameter(sp, "mu", 0.592)
-
-      """ ->
+# Examples
+```julia
+julia> import YT
+julia> ds = YT.load("GasSloshing/sloshing_nomag2_hdf5_plt_cnt_0100")
+julia> sp = YT.Sphere(ds, "c", (200.,"kpc"))
+julia> set_field_parameter(sp, "mu", 0.592)
+```
+"""
 function set_field_parameter(dc::DataContainer, key::String, value)
     v = PyObject(value)
     dc.cont[:set_field_parameter](key, v)
 end
 
-@doc doc"""
-      Check if a field parameter is set in a data container object.
+"""
+    has_field_parameter(dc::DataContainer, key::String)
 
-      Arguments:
+Check if a field parameter is set in a data container object.
 
-      * `dc::DataContainer`: The data container object to check for
-        a parameter.
-      * `key::String`: The name of the parameter to check.
+# Arguments
 
-      Examples:
+* `dc::DataContainer`: The data container object to check for a parameter.
+* `key::String`: The name of the parameter to check.
 
-          julia> import YT
-          julia> ds = YT.load("GasSloshing/sloshing_nomag2_hdf5_plt_cnt_0100")
-          julia> sp = YT.Sphere(ds, "c", (200.,"kpc"))
-          julia> has_field_parameter(sp, "center")
-      """ ->
+# Examples
+```julia
+julia> import YT
+julia> ds = YT.load("GasSloshing/sloshing_nomag2_hdf5_plt_cnt_0100")
+julia> sp = YT.Sphere(ds, "c", (200., "kpc"))
+julia> has_field_parameter(sp, "center")
+```
+"""
 function has_field_parameter(dc::DataContainer, key::String)
     dc.cont[:has_field_parameter](key)
 end
 
-@doc doc"""
-      Get the value of a field parameter.
+"""
+    get_field_parameter(dc::DataContainer, key::String)
 
-      Arguments:
+Get the value of a field parameter.
 
-      * `dc::DataContainer`: The data container object to get the
-        parameter from.
-      * `key::String`: The name of the parameter to get.
+# Arguments
 
-      Examples:
+* `dc::DataContainer`: The data container object to get the parameter from.
+* `key::String`: The name of the parameter to get.
 
-          julia> import YT
-          julia> ds = YT.load("GasSloshing/sloshing_nomag2_hdf5_plt_cnt_0100")
-          julia> sp = YT.Sphere(ds, "c", (200.,"kpc"))
-          julia> ctr = get_field_parameter(sp, "center")
-
-      """ ->
+# Examples
+```julia
+julia> import YT
+julia> ds = YT.load("GasSloshing/sloshing_nomag2_hdf5_plt_cnt_0100")
+julia> sp = YT.Sphere(ds, "c", (200.,"kpc"))
+julia> ctr = get_field_parameter(sp, "center")
+```
+"""
 function get_field_parameter(dc::DataContainer, key::String)
     v = pycall(dc.cont["get_field_parameter"], PyObject, key)
     if contains(pystring(v), "YTArray") || contains(pystring(v), "YTQuantity")
@@ -898,22 +946,24 @@ function get_field_parameter(dc::DataContainer, key::String)
     return v
 end
 
-@doc doc"""
-      Get all of the field parameters from a data container. Returns
-      a dictionary of field parameters.
+"""
+    get_field_parameters(dc::DataContainer)
 
-      Arguments:
+Get all of the field parameters from a data container. Returns
+a dictionary of field parameters.
 
-      * `dc::DataContainer`: The data container object to get the
-        parameters from.
+# Arguments
 
-      Examples:
+* `dc::DataContainer`: The data container object to get the parameters from.
 
-          julia> import YT
-          julia> ds = YT.load("GasSloshing/sloshing_nomag2_hdf5_plt_cnt_0100")
-          julia> sp = YT.Sphere(ds, "c", (200.,"kpc"))
-          julia> field_parameters = get_field_parameters(sp)
-      """ ->
+# Examples
+```julia
+julia> import YT
+julia> ds = YT.load("GasSloshing/sloshing_nomag2_hdf5_plt_cnt_0100")
+julia> sp = YT.Sphere(ds, "c", (200.,"kpc"))
+julia> field_parameters = get_field_parameters(sp)
+```
+"""
 function get_field_parameters(dc::DataContainer)
     fp = Dict()
     for k in collect(keys(dc.cont[:field_parameters]))

--- a/src/dataset_series.jl
+++ b/src/dataset_series.jl
@@ -31,7 +31,7 @@ import PyCall: @pyimport, PyObject
 type DatasetSeries
     ts::PyObject
     num_ds::Int
-    function DatasetSeries(fns::Array{String},1})
+    function DatasetSeries(fns::Array{String,1})
         ts = time_series.DatasetSeries(fns)
         num_ds = length(fns)
         new(ts, num_ds)

--- a/src/dataset_series.jl
+++ b/src/dataset_series.jl
@@ -9,7 +9,7 @@ import PyCall: @pyimport, PyObject
 
 @doc doc"""
       Construct a time series sequence of datasets
-      from an array of filenames, `fns::Array{Union{ASCIIString,UTF8String},1}`.
+      from an array of filenames, `fns::Array{Union{String,UTF8String},1}`.
 
       Examples:
 
@@ -31,7 +31,7 @@ import PyCall: @pyimport, PyObject
 type DatasetSeries
     ts::PyObject
     num_ds::Int
-    function DatasetSeries(fns::Array{Union{ASCIIString,UTF8String},1})
+    function DatasetSeries(fns::Array{Union{String,UTF8String},1})
         ts = time_series.DatasetSeries(fns)
         num_ds = length(fns)
         new(ts, num_ds)

--- a/src/dataset_series.jl
+++ b/src/dataset_series.jl
@@ -31,7 +31,7 @@ import PyCall: @pyimport, PyObject
 type DatasetSeries
     ts::PyObject
     num_ds::Int
-    function DatasetSeries(fns::Array{Union{String,UTF8String},1})
+    function DatasetSeries(fns::Array{String},1})
         ts = time_series.DatasetSeries(fns)
         num_ds = length(fns)
         new(ts, num_ds)

--- a/src/dataset_series.jl
+++ b/src/dataset_series.jl
@@ -7,27 +7,29 @@ import PyCall: @pyimport, PyObject
 
 @pyimport yt.data_objects.time_series as time_series
 
-@doc doc"""
-      Construct a time series sequence of datasets
-      from an array of filenames, `fns::Array{Union{String,UTF8String},1}`.
+"""
+    DatasetSeries(fns::Array{String,1})
 
-      Examples:
+Construct a time series sequence of datasets
+from an array of filenames.
 
-          julia> using YT
-          julia> using Glob
-          julia> fns = sort(glob("sloshing_low_res_hdf5_plt_cnt_0*"))
-          julia> time = YTQuantity[]
-          julia> max_dens = YTQuantity[]
-          julia> ts = DatasetSeries(fns)
-          julia> for ds in ts
-                     append!(time, [ds.current_time])
-                     sp = Sphere(ds, "c", (100.,"kpc"))
-                     append!(max_dens, [maximum(sp["density"])])
-                 end
-          julia> time = YTArray(time)
-          julia> max_dens = YTArray(max_dens)
-
-      """ ->
+# Examples
+```julia
+julia> using YT
+julia> using Glob
+julia> fns = sort(glob("sloshing_low_res_hdf5_plt_cnt_0*"))
+julia> time = YTQuantity[]
+julia> max_dens = YTQuantity[]
+julia> ts = DatasetSeries(fns)
+julia> for ds in ts
+           append!(time, [ds.current_time])
+           sp = Sphere(ds, "c", (100.,"kpc"))
+           append!(max_dens, [maximum(sp["density"])])
+       end
+julia> time = YTArray(time)
+julia> max_dens = YTArray(max_dens)
+```
+"""
 type DatasetSeries
     ts::PyObject
     num_ds::Int

--- a/src/fixed_resolution.jl
+++ b/src/fixed_resolution.jl
@@ -5,7 +5,7 @@ import PyCall: PyObject
 import ..array: YTArray, YTQuantity
 import Base: show, getindex
 
-Field  = Union{ASCIIString,Tuple{ASCIIString,ASCIIString}}
+Field  = Union{String,Tuple{String,String}}
 
 # FixedResolutionBuffer
 
@@ -25,8 +25,8 @@ function getindex(frb::FixedResolutionBuffer, field::Field)
     return frb.data[field]
 end
 
-getindex(frb::FixedResolutionBuffer, ftype::ASCIIString,
-         fname::ASCIIString) = getindex(frb, (ftype, fname))
+getindex(frb::FixedResolutionBuffer, ftype::String,
+         fname::String) = getindex(frb, (ftype, fname))
 
 function show(io::IO, frb::FixedResolutionBuffer)
     println(io,"FixedResolutionBuffer ($(frb.buff_size[1])x$(frb.buff_size[2]))")

--- a/src/plots.jl
+++ b/src/plots.jl
@@ -18,39 +18,39 @@ A plot of a slice through the simulation domain.
 
 * `ds::Dataset`: The dataset to be used.
 * `axis`: The axis to slice perpendicular to. Can be a string ("x", "y",
-  or "z"), integer (0,1, or 2), or a three-element `Array` (e.g.,
+  or "z"), integer (0, 1, or 2), or a three-element `Array` (e.g.,
   [0.1, 0.3, -0.5]), for an off-axis slice.
 * `fields`: A single field, e.g. "density" or ("flash", "dens"), or `Array`
   of fields.
-* `center` (optional): The coordinate of the center of the image. A sequence
-  of floats, a string, or a tuple. If set to 'c', 'center' or left blank,
-  the plot is centered on the middle of the domain. If set to 'max' or 'm',
-  the center will be located at the maximum of the ('gas', 'density') field.
-  Centering on the max or min of a specific field is supported by providing a
-  tuple such as ("min", "temperature") or ("max", "dark_matter_density").
-  Units can be specified by passing in `center` as a tuple containing a
-  coordinate and string unit name or by passing in a `YTArray`. If a list or
-  unitless array is supplied, code units are assumed.
-* `width` (optional): The width of the slice. Width can have four different
+* `center="c"`: The coordinate of the center of the image. A sequence
+  of floats, a string, or a tuple. If set to "c" or "center", the plot is
+  centered on the middle of the domain. If set to "max" or "m", the center
+  will be located at the maximum of the ("gas", "density") field. Centering
+  on the max or min of a specific field is supported by providing a tuple
+  such as ("min", "temperature") or ("max", "dark_matter_density"). Units
+  can be specified by passing in `center` as a tuple containing a coordinate
+  and string unit name or by passing in a `YTArray`. If a list or unitless
+  array is supplied, code units are assumed.
+* `width=nothing`: The width of the slice. Width can have four different
   formats to support windows with variable x and y widths. They are:
 
   ==================================     =======================
   format                                 example
   ==================================     =======================
-  (float, string)                        (10,'kpc')
-  ((float, string), (float, string))     ((10,'kpc'),(15,'kpc'))
+  (float, string)                        (10, "kpc")
+  ((float, string), (float, string))     ((10, "kpc"), (15, "kpc"))
   float                                  0.2
   (float, float)                         (0.2, 0.3)
   ==================================     =======================
 
-  For example, (10, 'kpc') requests a plot window that is 10 kiloparsecs
-  wide in the x and y directions, ((10,'kpc'),(15,'kpc')) requests a window
+  For example, (10, "kpc") requests a plot window that is 10 kiloparsecs
+  wide in the x and y directions, ((10, "kpc"), (15, "kpc")) requests a window
   that is 10 kiloparsecs wide along the x axis and 15 kiloparsecs wide along
   the y axis. In the other two examples, code units are assumed, for example
   (0.2, 0.3) requests a plot that has an x width of 0.2 and a y width of 0.3
   in code units.  If units are provided the resulting plot axis labels will
   use the supplied units.
-* `field_parameters::Dict{String,Any}` (optional): A dictionary of field
+* `field_parameters::Dict{String,Any}=nothing`: A dictionary of field
   parameters than can be accessed by derived fields.
 
 Other optional arguments are handled by `yt`, consult the `yt` documentation
@@ -86,43 +86,43 @@ A plot of an on-axis projection through the simulation domain.
 
 * `ds::Dataset`: The dataset to be used.
 * `axis`: The axis to slice perpendicular to. Can be a string ("x", "y", or
-  "z"), or an integer (0,1,2).
-* `fields`: A single field, e.g. "density" or ("flash","dens"), or `Array` of
+  "z"), or an integer (0, 1, 2).
+* `fields`: A single field, e.g. "density" or ("flash", "dens"), or `Array` of
   fields.
-* `weight_field` (optional): The field to weight the projection by. Default is
-  `nothing`, an unweighted projection.
-* `center` (optional): The coordinate of the center of the image. A sequence of
-  floats, a string, or a tuple. If set to 'c', 'center' or left blank, the plot
-  is centered on the middle of the domain. If set to 'max' or 'm', the center
-  will be located at the maximum of the ('gas', 'density') field. Centering on
-  the max or min of a specific field is supported by providing a tuple such as
-  ("min","temperature") or ("max","dark_matter_density"). Units can be specified
-  by passing in `center` as a tuple containing a coordinate and string unit name
-  or by passing in a YTArray. If a list or unitless array is supplied, code
-  units are assumed.
-* `width` (optional): The width of the projection. Width can have four different
+* `weight_field=nothing`: The field to weight the projection by. Default is
+  an unweighted projection.
+* `center="c"`: The coordinate of the center of the image. A sequence of
+  floats, a string, or a tuple. If set to "c" or "center", the plot is centered
+  on the middle of the domain. If set to "max" or "m", the center will be
+  located at the maximum of the ("gas", "density") field. Centering on the max
+  or min of a specific field is supported by providing a tuple such as
+  ("min", "temperature") or ("max", "dark_matter_density"). Units can be
+  specified by passing in `center` as a tuple containing a coordinate and
+  string unit name or by passing in a `YTArray`. If a list or unitless array is
+  supplied, code units are assumed.
+* `width=nothing`: The width of the projection. Width can have four different
   formats to support windows with variable x and y widths. They are:
 
   ==================================     =======================
   format                                 example
   ==================================     =======================
-  (float, string)                        (10,'kpc')
-  ((float, string), (float, string))     ((10,'kpc'),(15,'kpc'))
+  (float, string)                        (10, "kpc")
+  ((float, string), (float, string))     ((10, "kpc"), (15, "kpc"))
   float                                  0.2
   (float, float)                         (0.2, 0.3)
   ==================================     =======================
 
-  For example, (10, 'kpc') requests a plot window that is 10 kiloparsecs wide in
-  the x and y directions, ((10,'kpc'),(15,'kpc')) requests a window that is 10
-  kiloparsecs wide along the x axis and 15 kiloparsecs wide along the y axis. In
-  the other two examples, code units are assumed, for example (0.2, 0.3)
+  For example, (10, "kpc") requests a plot window that is 10 kiloparsecs wide in
+  the x and y directions, ((10, "kpc"), (15, "kpc")) requests a window that is
+  10 kiloparsecs wide along the x axis and 15 kiloparsecs wide along the y axis.
+  In the other two examples, code units are assumed, for example (0.2, 0.3)
   requests a plot that has an x width of 0.2 and a y width of 0.3 in code units.
   If units are provided the resulting plot axis labels will use the supplied
   units.
-* `data_source::DataContainer` (optional): An optional data source to use when
+* `data_source::DataContainer=nothing`: An optional data source to use when
   making the projection. Only the elements which have coordinates within the
   `data_source` will be used in the projection.
-* `field_parameters::Dict{String,Any}` (optional): A dictionary of
+* `field_parameters::Dict{String,Any}=nothing`: A dictionary of
   field parameters than can be accessed by derived fields.
 
 Other optional arguments are handled by `yt`, consult the `yt` documentation for
@@ -132,9 +132,9 @@ details.
 ```julia
 julia> import YT
 julia> ds = YT.load("RedshiftOutput0005")
-julia> sp = YT.Sphere(ds, "max", (0.5,"Mpc"))
-julia> prj = YT.ProjectionPlot(ds, "z", ["density","temperature"];
-                               data_source=sp, center="max", width=(2.0,"Mpc"))
+julia> sp = YT.Sphere(ds, "max", (0.5, "Mpc"))
+julia> prj = YT.ProjectionPlot(ds, "z", ["density", "temperature"];
+                               data_source=sp, center="max", width=(2.0, "Mpc"))
 ```
 """
 function ProjectionPlot(ds::Dataset, axis, fields; weight_field=nothing,

--- a/src/plots.jl
+++ b/src/plots.jl
@@ -51,7 +51,7 @@ A plot of a slice through the simulation domain.
   in code units.  If units are provided the resulting plot axis labels will
   use the supplied units.
 * `field_parameters::Dict{String,Any}=nothing`: A dictionary of field
-  parameters than can be accessed by derived fields.
+  parameters that can be accessed by derived fields.
 
 Other optional arguments are handled by `yt`, consult the `yt` documentation
 for details.
@@ -123,7 +123,7 @@ A plot of an on-axis projection through the simulation domain.
   making the projection. Only the elements which have coordinates within the
   `data_source` will be used in the projection.
 * `field_parameters::Dict{String,Any}=nothing`: A dictionary of
-  field parameters than can be accessed by derived fields.
+  field parameters that can be accessed by derived fields.
 
 Other optional arguments are handled by `yt`, consult the `yt` documentation for
 details.

--- a/src/plots.jl
+++ b/src/plots.jl
@@ -45,7 +45,7 @@ import PyCall: @pyimport, PyObject, pywrap
         examples, code units are assumed, for example (0.2, 0.3) requests a plot that has an
         x width of 0.2 and a y width of 0.3 in code units.  If units are provided the resulting
         plot axis labels will use the supplied units.
-      * `field_parameters::Dict{ASCIIString,Any}` (optional): A dictionary of
+      * `field_parameters::Dict{String,Any}` (optional): A dictionary of
         field parameters than can be accessed by derived fields.
 
       Other optional arguments are handled by `yt`, consult the `yt` documentation for details.
@@ -109,7 +109,7 @@ end
       * `data_source::DataContainer` (optional): An optional data source to use when
         making the projection. Only the elements which have coordinates within the
         `data_source` will be used in the projection.
-      * `field_parameters::Dict{ASCIIString,Any}` (optional): A dictionary of
+      * `field_parameters::Dict{String,Any}` (optional): A dictionary of
         field parameters than can be accessed by derived fields.
 
       Other optional arguments are handled by `yt`, consult the `yt` documentation for details.

--- a/src/plots.jl
+++ b/src/plots.jl
@@ -8,54 +8,61 @@ import PyCall: @pyimport, PyObject, pywrap
 @pyimport yt.visualization.plot_window as pw
 @pyimport yt.visualization.profile_plotter as pp
 
-@doc doc"""
-      A plot of a slice through the simulation domain.
+"""
+    SlicePlot(ds::Dataset, axis, fields; center="c", width=nothing,
+              field_parameters=nothing, args...)
 
-      Arguments:
+A plot of a slice through the simulation domain.
 
-      * `ds::Dataset`: The dataset to be used.
-      * `axis`: The axis to slice perpendicular to. Can be a string ("x","y", or "z"),
-        integer (0,1, or 2), or a three-element `Array` (e.g., [0.1,0.3,-0.5]), for an
-        off-axis slice.
-      * `fields`: A single field, e.g. "density" or ("flash","dens"), or `Array` of fields.
-      * `center` (optional): The coordinate of the center of the image. A sequence of
-        floats, a string, or a tuple. If set to 'c', 'center' or left blank, the plot
-        is centered on the middle of the domain. If set to 'max' or 'm', the center
-        will be located at the maximum of the ('gas', 'density') field. Centering on
-        the max or min of a specific field is supported by providing a tuple such as
-        ("min","temperature") or ("max","dark_matter_density"). Units can be specified
-        by passing in `center` as a tuple containing a coordinate and string unit name
-        or by passing in a YTArray. If a list or unitless array is supplied, code units
-        are assumed.
-      * `width` (optional): The width of the slice. Width can have four different formats
-        to support windows with variable x and y widths. They are:
+# Arguments
 
-        ==================================     =======================
-        format                                 example
-        ==================================     =======================
-        (float, string)                        (10,'kpc')
-        ((float, string), (float, string))     ((10,'kpc'),(15,'kpc'))
-        float                                  0.2
-        (float, float)                         (0.2, 0.3)
-        ==================================     =======================
+* `ds::Dataset`: The dataset to be used.
+* `axis`: The axis to slice perpendicular to. Can be a string ("x", "y",
+  or "z"), integer (0,1, or 2), or a three-element `Array` (e.g.,
+  [0.1, 0.3, -0.5]), for an off-axis slice.
+* `fields`: A single field, e.g. "density" or ("flash", "dens"), or `Array`
+  of fields.
+* `center` (optional): The coordinate of the center of the image. A sequence
+  of floats, a string, or a tuple. If set to 'c', 'center' or left blank,
+  the plot is centered on the middle of the domain. If set to 'max' or 'm',
+  the center will be located at the maximum of the ('gas', 'density') field.
+  Centering on the max or min of a specific field is supported by providing a
+  tuple such as ("min", "temperature") or ("max", "dark_matter_density").
+  Units can be specified by passing in `center` as a tuple containing a
+  coordinate and string unit name or by passing in a `YTArray`. If a list or
+  unitless array is supplied, code units are assumed.
+* `width` (optional): The width of the slice. Width can have four different
+  formats to support windows with variable x and y widths. They are:
 
-        For example, (10, 'kpc') requests a plot window that is 10 kiloparsecs wide in the
-        x and y directions, ((10,'kpc'),(15,'kpc')) requests a window that is 10 kiloparsecs
-        wide along the x axis and 15 kiloparsecs wide along the y axis. In the other two
-        examples, code units are assumed, for example (0.2, 0.3) requests a plot that has an
-        x width of 0.2 and a y width of 0.3 in code units.  If units are provided the resulting
-        plot axis labels will use the supplied units.
-      * `field_parameters::Dict{String,Any}` (optional): A dictionary of
-        field parameters than can be accessed by derived fields.
+  ==================================     =======================
+  format                                 example
+  ==================================     =======================
+  (float, string)                        (10,'kpc')
+  ((float, string), (float, string))     ((10,'kpc'),(15,'kpc'))
+  float                                  0.2
+  (float, float)                         (0.2, 0.3)
+  ==================================     =======================
 
-      Other optional arguments are handled by `yt`, consult the `yt` documentation for details.
+  For example, (10, 'kpc') requests a plot window that is 10 kiloparsecs
+  wide in the x and y directions, ((10,'kpc'),(15,'kpc')) requests a window
+  that is 10 kiloparsecs wide along the x axis and 15 kiloparsecs wide along
+  the y axis. In the other two examples, code units are assumed, for example
+  (0.2, 0.3) requests a plot that has an x width of 0.2 and a y width of 0.3
+  in code units.  If units are provided the resulting plot axis labels will
+  use the supplied units.
+* `field_parameters::Dict{String,Any}` (optional): A dictionary of field
+  parameters than can be accessed by derived fields.
 
-      Examples:
+Other optional arguments are handled by `yt`, consult the `yt` documentation
+for details.
 
-          julia> import YT
-          julia> ds = YT.load("RedshiftOutput0005")
-          julia> slc = YT.SlicePlot(ds, "z", ["density","temperature"])
-      """ ->
+# Examples
+```julia
+julia> import YT
+julia> ds = YT.load("RedshiftOutput0005")
+julia> slc = YT.SlicePlot(ds, "z", ["density","temperature"])
+```
+"""
 function SlicePlot(ds::Dataset, axis, fields; center="c",
                    width=nothing, field_parameters=nothing, args...)
     if typeof(center) <: YTArray
@@ -68,60 +75,68 @@ function SlicePlot(ds::Dataset, axis, fields; center="c",
                         width=width, field_parameters=fps, args...))
 end
 
-@doc doc"""
-      A plot of an on-axis projection through the simulation domain.
+"""
+    ProjectionPlot(ds::Dataset, axis, fields; weight_field=nothing,
+                   center="c", width=nothing, data_source=nothing,
+                   field_parameters=nothing, args...)
 
-      Arguments:
+A plot of an on-axis projection through the simulation domain.
 
-      * `ds::Dataset`: The dataset to be used.
-      * `axis`: The axis to slice perpendicular to. Can be a string ("x","y", or "z"),
-        or an integer (0,1,2).
-      * `fields`: A single field, e.g. "density" or ("flash","dens"), or `Array` of fields.
-      * `weight_field` (optional): The field to weight the projection by. Default is
-        `nothing`, an unweighted projection.
-      * `center` (optional): The coordinate of the center of the image. A sequence of
-        floats, a string, or a tuple. If set to 'c', 'center' or left blank, the plot
-        is centered on the middle of the domain. If set to 'max' or 'm', the center
-        will be located at the maximum of the ('gas', 'density') field. Centering on
-        the max or min of a specific field is supported by providing a tuple such as
-        ("min","temperature") or ("max","dark_matter_density"). Units can be specified
-        by passing in `center` as a tuple containing a coordinate and string unit name
-        or by passing in a YTArray. If a list or unitless array is supplied, code units
-        are assumed.
-      * `width` (optional): The width of the projection. Width can have four different
-        formats to support windows with variable x and y widths. They are:
+# Arguments
 
-        ==================================     =======================
-        format                                 example
-        ==================================     =======================
-        (float, string)                        (10,'kpc')
-        ((float, string), (float, string))     ((10,'kpc'),(15,'kpc'))
-        float                                  0.2
-        (float, float)                         (0.2, 0.3)
-        ==================================     =======================
+* `ds::Dataset`: The dataset to be used.
+* `axis`: The axis to slice perpendicular to. Can be a string ("x", "y", or
+  "z"), or an integer (0,1,2).
+* `fields`: A single field, e.g. "density" or ("flash","dens"), or `Array` of
+  fields.
+* `weight_field` (optional): The field to weight the projection by. Default is
+  `nothing`, an unweighted projection.
+* `center` (optional): The coordinate of the center of the image. A sequence of
+  floats, a string, or a tuple. If set to 'c', 'center' or left blank, the plot
+  is centered on the middle of the domain. If set to 'max' or 'm', the center
+  will be located at the maximum of the ('gas', 'density') field. Centering on
+  the max or min of a specific field is supported by providing a tuple such as
+  ("min","temperature") or ("max","dark_matter_density"). Units can be specified
+  by passing in `center` as a tuple containing a coordinate and string unit name
+  or by passing in a YTArray. If a list or unitless array is supplied, code
+  units are assumed.
+* `width` (optional): The width of the projection. Width can have four different
+  formats to support windows with variable x and y widths. They are:
 
-        For example, (10, 'kpc') requests a plot window that is 10 kiloparsecs wide in the
-        x and y directions, ((10,'kpc'),(15,'kpc')) requests a window that is 10 kiloparsecs
-        wide along the x axis and 15 kiloparsecs wide along the y axis. In the other two
-        examples, code units are assumed, for example (0.2, 0.3) requests a plot that has an
-        x width of 0.2 and a y width of 0.3 in code units.  If units are provided the resulting
-        plot axis labels will use the supplied units.
-      * `data_source::DataContainer` (optional): An optional data source to use when
-        making the projection. Only the elements which have coordinates within the
-        `data_source` will be used in the projection.
-      * `field_parameters::Dict{String,Any}` (optional): A dictionary of
-        field parameters than can be accessed by derived fields.
+  ==================================     =======================
+  format                                 example
+  ==================================     =======================
+  (float, string)                        (10,'kpc')
+  ((float, string), (float, string))     ((10,'kpc'),(15,'kpc'))
+  float                                  0.2
+  (float, float)                         (0.2, 0.3)
+  ==================================     =======================
 
-      Other optional arguments are handled by `yt`, consult the `yt` documentation for details.
+  For example, (10, 'kpc') requests a plot window that is 10 kiloparsecs wide in
+  the x and y directions, ((10,'kpc'),(15,'kpc')) requests a window that is 10
+  kiloparsecs wide along the x axis and 15 kiloparsecs wide along the y axis. In
+  the other two examples, code units are assumed, for example (0.2, 0.3)
+  requests a plot that has an x width of 0.2 and a y width of 0.3 in code units.
+  If units are provided the resulting plot axis labels will use the supplied
+  units.
+* `data_source::DataContainer` (optional): An optional data source to use when
+  making the projection. Only the elements which have coordinates within the
+  `data_source` will be used in the projection.
+* `field_parameters::Dict{String,Any}` (optional): A dictionary of
+  field parameters than can be accessed by derived fields.
 
-      Examples:
+Other optional arguments are handled by `yt`, consult the `yt` documentation for
+details.
 
-          julia> import YT
-          julia> ds = YT.load("RedshiftOutput0005")
-          julia> sp = YT.Sphere(ds, "max", (0.5,"Mpc"))
-          julia> prj = YT.ProjectionPlot(ds, "z", ["density","temperature"];
-                                         data_source=sp, center="max", width=(2.0,"Mpc"))
-      """ ->
+# Examples
+```julia
+julia> import YT
+julia> ds = YT.load("RedshiftOutput0005")
+julia> sp = YT.Sphere(ds, "max", (0.5,"Mpc"))
+julia> prj = YT.ProjectionPlot(ds, "z", ["density","temperature"];
+                               data_source=sp, center="max", width=(2.0,"Mpc"))
+```
+"""
 function ProjectionPlot(ds::Dataset, axis, fields; weight_field=nothing,
                         center="c", width=nothing, data_source=nothing,
                         field_parameters=nothing, args...)
@@ -143,9 +158,11 @@ end
 
 # Show plot
 
-@doc doc"""
-      Show the `plot` in the IJulia notebook.
-      """ ->
+"""
+    show_plot(plot)
+
+Show the `plot` in the IJulia notebook.
+"""
 function show_plot(plot)
     plot.refresh()
 end

--- a/src/profiles.jl
+++ b/src/profiles.jl
@@ -25,29 +25,29 @@ Bin data from a data container object into a profile. These can be in
   The number of fields decides whether or not this will be a 1D, 2D, or 3D
   profile. If a single field string is given, it is assumed to be 1D.
 * `fields`: A single field or `Array` of fields to be binned.
-* `n_bins`: A single integer or tuple of 2 or 3 integers, to determine the
+* `n_bins=64`: A single integer or tuple of 2 or 3 integers, to determine the
   number of bins along each dimension.
-* `extrema::Dict{String,Any}`: A dictionary of tuples (with the field names
-  as the keys) that determine the maximum and minimum of the bin ranges,
+* `extrema::Dict{String,Any}=nothing`: A dictionary of tuples (with the field
+  names as the keys) that determine the maximum and minimum of the bin ranges,
   e.g. Dict("density"=>(1.0e-30, 1.0e-25)). If a field's extrema are not
   specified, the extrema of the field in the `data_source` are assumed. The
   extrema are assumed to be in the units of the field in the `units` argument
   unless it is not specified, otherwise they are in the field's default units.
-* `logs::Dict{String,Bool}`: A dictionary (with the field names as the keys)
-  that determines whether the bins are in logspace or linear space, e.g.
+* `logs::Dict{String,Bool}=nothing`: A dictionary (with the field names as the
+  keys) that determines whether the bins are in logspace or linear space, e.g.
   Dict("radius"=>false). If not set, the `take_log` attribute for the field
   determines this.
-* `units`: A dictionary (with the field names as the keys) that determines
-  the units of the field, e.g. Dict("density"=>"Msun/kpc^3"). If not set
-  then the default units for the field are used.
-* `weight_field`: The field to weight the binned fields by when binning. Can
-  be a field name or `nothing`, to produce an unweighted profile. `"cell_mass"`
-  is the default.
-* `accumulation::Bool`: If `true`, the profile values for a bin n are the
+* `units::Dict{String,String}=nothing`: A dictionary (with the field names
+  as the keys) that determines the units of the field, e.g.
+  Dict("density"=>"Msun/kpc^3"). If not set then the default units for the
+  field are used.
+* `weight_field="cell_mass"`: The field to weight the binned fields by when
+  binning. Can be a field name or `nothing`, to produce an unweighted profile.
+* `accumulation::Bool=false`: If `true`, the profile values for a bin n are the
   cumulative sum of all the values from bin 1 to n. If the profile is 2D or
   3D, an `Array{Bool,1}` of values can be given to control the summation in
   each dimension independently.
-* `fractional::Bool`: If `true`, the profile values are divided by the sum
+* `fractional::Bool=false`: If `true`, the profile values are divided by the sum
   of all of the values.
 
 # Examples

--- a/src/profiles.jl
+++ b/src/profiles.jl
@@ -6,7 +6,7 @@ import ..data_objects: DataContainer
 import ..array: YTArray, convert_to_units
 @pyimport yt.data_objects.profiles as prof
 
-Field  = Union{ASCIIString,Tuple{ASCIIString,ASCIIString}}
+Field  = Union{String,Tuple{String,String}}
 
 @doc doc"""
 
@@ -23,12 +23,12 @@ Field  = Union{ASCIIString,Tuple{ASCIIString,ASCIIString}}
       * `fields`: A single field or `Array` of fields to be binned.
       * `n_bins`: A single integer or tuple of 2 or 3 integers, to determine the number of bins along
         each dimension.
-      * `extrema::Dict{ASCIIString,Any}`: A dictionary of tuples (with the field names as the keys) that
+      * `extrema::Dict{String,Any}`: A dictionary of tuples (with the field names as the keys) that
         determine the maximum and minimum of the bin ranges, e.g. Dict("density"=>(1.0e-30, 1.0e-25)). If a
         field's extrema are not specified, the extrema of the field in the `data_source` are assumed. The
         extrema are assumed to be in the units of the field in the `units` argument unless it is not
         specified, otherwise they are in the field's default units.
-      * `logs::Dict{ASCIIString,Bool}`: A dictionary (with the field names as the keys) that determines whether
+      * `logs::Dict{String,Bool}`: A dictionary (with the field names as the keys) that determines whether
         the bins are in logspace or linear space, e.g. Dict("radius"=>false). If not set, the `take_log`
         attribute for the field determines this.
       * `units`: A dictionary (with the field names as the keys) that determines the units
@@ -114,9 +114,9 @@ end
       Arguments:
 
       * `profile::YTProfile`: The profile to use.
-      * `new_unit::ASCIIString`: The new unit.
+      * `new_unit::String`: The new unit.
       """ ->
-function set_x_unit(profile::YTProfile, new_unit::ASCIIString)
+function set_x_unit(profile::YTProfile, new_unit::String)
     profile.profile[:set_x_unit](new_unit)
     profile.x = YTArray(profile.profile["x"])
     profile.x_bins = YTArray(profile.profile["x_bins"])
@@ -129,9 +129,9 @@ end
       Arguments:
 
       * `profile::YTProfile`: The profile to use.
-      * `new_unit::ASCIIString`: The new unit.
+      * `new_unit::String`: The new unit.
       """ ->
-function set_y_unit(profile::YTProfile, new_unit::ASCIIString)
+function set_y_unit(profile::YTProfile, new_unit::String)
     profile.profile[:set_y_unit](new_unit)
     profile.y = YTArray(profile.profile["y"])
     profile.y_bins = YTArray(profile.profile["y_bins"])
@@ -144,9 +144,9 @@ end
       Arguments:
 
       * `profile::YTProfile`: The profile to use.
-      * `new_unit::ASCIIString`: The new unit.
+      * `new_unit::String`: The new unit.
       """ ->
-function set_z_unit(profile::YTProfile, new_unit::ASCIIString)
+function set_z_unit(profile::YTProfile, new_unit::String)
     profile.profile[:set_z_unit](new_unit)
     profile.z = YTArray(profile.profile["z"])
     profile.z_bins = YTArray(profile.profile["z_bins"])
@@ -159,15 +159,15 @@ end
       Arguments:
 
       * `profile::YTProfile`: The profile to use.
-      * `field::ASCIIString`: The name of the field to change the unit for.
-      * `new_unit::ASCIIString`: The new unit.
+      * `field::String`: The name of the field to change the unit for.
+      * `new_unit::String`: The new unit.
       """ ->
-function set_field_unit(profile::YTProfile, field::ASCIIString, new_unit::ASCIIString)
+function set_field_unit(profile::YTProfile, field::String, new_unit::String)
     profile.unit_dict[field] = new_unit
     return
 end
 
-function getindex(profile::YTProfile, field::ASCIIString)
+function getindex(profile::YTProfile, field::String)
     if !haskey(profile.field_dict, field)
         profile.field_dict[field] = YTArray(get(profile.profile, PyObject, field))
     end
@@ -181,7 +181,7 @@ end
 @doc doc"""
       Get the variance of a field from the `YTProfile`.
       """ ->
-function variance(profile::YTProfile, field::ASCIIString)
+function variance(profile::YTProfile, field::String)
     if !haskey(profile.var_dict, field)
         fd = profile.source.cont[:_determine_fields](field)[1]
         profile.var_dict[field] = YTArray(get(profile.profile["variance"],

--- a/src/profiles.jl
+++ b/src/profiles.jl
@@ -8,49 +8,60 @@ import ..array: YTArray, convert_to_units
 
 Field  = Union{String,Tuple{String,String}}
 
-@doc doc"""
+"""
+    YTProfile(data_source::DataContainer, bin_fields, fields;
+              n_bins=64, extrema=nothing, logs=nothing,
+              units=nothing, weight_field="cell_mass",
+              accumulation=false, fractional=false)
 
-      Bin data from a data container object into a profile. These can be in
-      1D, 2D, or 3D.
+Bin data from a data container object into a profile. These can be in
+1D, 2D, or 3D.
 
-      Arguments:
+# Arguments
 
-      * `data_source::DataContainer`: The object containing the data from which the profile is
-        to be created.
-      * `bin_fields`: An `Array` of field names over which the binning will occur. The number of
-        fields decides whether or not this will be a 1D, 2D, or 3D profile. If a single field string is
-        given, it is assumed to be 1D.
-      * `fields`: A single field or `Array` of fields to be binned.
-      * `n_bins`: A single integer or tuple of 2 or 3 integers, to determine the number of bins along
-        each dimension.
-      * `extrema::Dict{String,Any}`: A dictionary of tuples (with the field names as the keys) that
-        determine the maximum and minimum of the bin ranges, e.g. Dict("density"=>(1.0e-30, 1.0e-25)). If a
-        field's extrema are not specified, the extrema of the field in the `data_source` are assumed. The
-        extrema are assumed to be in the units of the field in the `units` argument unless it is not
-        specified, otherwise they are in the field's default units.
-      * `logs::Dict{String,Bool}`: A dictionary (with the field names as the keys) that determines whether
-        the bins are in logspace or linear space, e.g. Dict("radius"=>false). If not set, the `take_log`
-        attribute for the field determines this.
-      * `units`: A dictionary (with the field names as the keys) that determines the units
-        of the field, e.g. Dict("density"=>"Msun/kpc^3"). If not set then the default units for the
-        field are used.
-      * `weight_field`: The field to weight the binned fields by when binning. Can be a field name or
-        `nothing`, to produce an unweighted profile. `"cell_mass"` is the default.
-      * `accumulation::Bool`: If `true`, the profile values for a bin n are the cumulative sum of all the
-        values from bin 1 to n. If the profile is 2D or 3D, an `Array{Bool,1}` of values can be given to
-        control the summation in each dimension independently.
-      * `fractional::Bool`: If `true`, the profile values are divided by the sum of all of the values.
+* `data_source::DataContainer`: The object containing the data from which the
+  profile is sto be created.
+* `bin_fields`: An `Array` of field names over which the binning will occur.
+  The number of fields decides whether or not this will be a 1D, 2D, or 3D
+  profile. If a single field string is given, it is assumed to be 1D.
+* `fields`: A single field or `Array` of fields to be binned.
+* `n_bins`: A single integer or tuple of 2 or 3 integers, to determine the
+  number of bins along each dimension.
+* `extrema::Dict{String,Any}`: A dictionary of tuples (with the field names
+  as the keys) that determine the maximum and minimum of the bin ranges,
+  e.g. Dict("density"=>(1.0e-30, 1.0e-25)). If a field's extrema are not
+  specified, the extrema of the field in the `data_source` are assumed. The
+  extrema are assumed to be in the units of the field in the `units` argument
+  unless it is not specified, otherwise they are in the field's default units.
+* `logs::Dict{String,Bool}`: A dictionary (with the field names as the keys)
+  that determines whether the bins are in logspace or linear space, e.g.
+  Dict("radius"=>false). If not set, the `take_log` attribute for the field
+  determines this.
+* `units`: A dictionary (with the field names as the keys) that determines
+  the units of the field, e.g. Dict("density"=>"Msun/kpc^3"). If not set
+  then the default units for the field are used.
+* `weight_field`: The field to weight the binned fields by when binning. Can
+  be a field name or `nothing`, to produce an unweighted profile. `"cell_mass"`
+  is the default.
+* `accumulation::Bool`: If `true`, the profile values for a bin n are the
+  cumulative sum of all the values from bin 1 to n. If the profile is 2D or
+  3D, an `Array{Bool,1}` of values can be given to control the summation in
+  each dimension independently.
+* `fractional::Bool`: If `true`, the profile values are divided by the sum
+  of all of the values.
 
-      Examples:
-
-          julia> sp = YT.Sphere(ds, "max", (1.0,"Mpc"))
-          julia> units=Dict("radius"=>"kpc")
-          julia> logs=Dict("radius"=>false)
-          julia> fields=Dict("density","temperature")
-          julia> profile = YT.YTProfile(sp, "radius", fields, n_bins=100, units=units, logs=logs)
-          julia> print(profile.x)
-          julia> print(profile["density"])
-      """ ->
+# Examples
+```julia
+julia> import YT
+julia> sp = YT.Sphere(ds, "max", (1.0,"Mpc"))
+julia> units=Dict("radius"=>"kpc")
+julia> logs=Dict("radius"=>false)
+julia> fields=Dict("density","temperature")
+julia> profile = YT.YTProfile(sp, "radius", fields, n_bins=100, units=units, logs=logs)
+julia> print(profile.x)
+julia> print(profile["density"])
+```
+"""
 type YTProfile
     profile::PyObject
     source::DataContainer
@@ -108,14 +119,11 @@ type YTProfile
     end
 end
 
-@doc doc"""
-      Set the unit of the x-axis of the profile.
+"""
+    set_x_unit(profile::YTProfile, new_unit::String)
 
-      Arguments:
-
-      * `profile::YTProfile`: The profile to use.
-      * `new_unit::String`: The new unit.
-      """ ->
+Set the unit of the x-axis of the profile.
+"""
 function set_x_unit(profile::YTProfile, new_unit::String)
     profile.profile[:set_x_unit](new_unit)
     profile.x = YTArray(profile.profile["x"])
@@ -123,14 +131,11 @@ function set_x_unit(profile::YTProfile, new_unit::String)
     return
 end
 
-@doc doc"""
-      Set the unit of the y-axis of the profile.
+"""
+    set_y_unit(profile::YTProfile, new_unit::String)
 
-      Arguments:
-
-      * `profile::YTProfile`: The profile to use.
-      * `new_unit::String`: The new unit.
-      """ ->
+Set the unit of the y-axis of the profile.
+"""
 function set_y_unit(profile::YTProfile, new_unit::String)
     profile.profile[:set_y_unit](new_unit)
     profile.y = YTArray(profile.profile["y"])
@@ -138,14 +143,11 @@ function set_y_unit(profile::YTProfile, new_unit::String)
     return
 end
 
-@doc doc"""
-      Set the unit of the z-axis of the profile.
+"""
+    set_z_unit(profile::YTProfile, new_unit::String)
 
-      Arguments:
-
-      * `profile::YTProfile`: The profile to use.
-      * `new_unit::String`: The new unit.
-      """ ->
+Set the unit of the z-axis of the profile.
+"""
 function set_z_unit(profile::YTProfile, new_unit::String)
     profile.profile[:set_z_unit](new_unit)
     profile.z = YTArray(profile.profile["z"])
@@ -153,15 +155,11 @@ function set_z_unit(profile::YTProfile, new_unit::String)
     return
 end
 
-@doc doc"""
-      Set the unit of a field in the profile.
+"""
+    set_field_unit(profile::YTProfile, field::String, new_unit::String)
 
-      Arguments:
-
-      * `profile::YTProfile`: The profile to use.
-      * `field::String`: The name of the field to change the unit for.
-      * `new_unit::String`: The new unit.
-      """ ->
+Set the unit of a field in the profile.
+"""
 function set_field_unit(profile::YTProfile, field::String, new_unit::String)
     profile.unit_dict[field] = new_unit
     return
@@ -178,9 +176,11 @@ function getindex(profile::YTProfile, field::String)
     profile.field_dict[field]
 end
 
-@doc doc"""
-      Get the variance of a field from the `YTProfile`.
-      """ ->
+"""
+    variance(profile::YTProfile, field::String)
+
+Get the variance of a field from the `YTProfile`.
+"""
 function variance(profile::YTProfile, field::String)
     if !haskey(profile.var_dict, field)
         fd = profile.source.cont[:_determine_fields](field)[1]

--- a/src/units.jl
+++ b/src/units.jl
@@ -10,13 +10,13 @@ prefixes = collect(keys(lut.unit_prefixes))
 prefixable_units = lut.prefixable_units
 
 for unit in base_units
-    u = symbol(unit)
+    u = Symbol(unit)
     @eval $u = YTQuantity(1.0, String($unit))
     if unit in lut.prefixable_units
         for prefix in prefixes
             pu = String(prefix*unit)
             if pu != "as"
-                u = symbol(pu)
+                u = Symbol(pu)
                 @eval $u = YTQuantity(1.0, $pu)
             end
         end

--- a/src/units.jl
+++ b/src/units.jl
@@ -11,10 +11,10 @@ prefixable_units = lut.prefixable_units
 
 for unit in base_units
     u = symbol(unit)
-    @eval $u = YTQuantity(1.0, ASCIIString($unit))
+    @eval $u = YTQuantity(1.0, String($unit))
     if unit in lut.prefixable_units
         for prefix in prefixes
-            pu = ASCIIString(prefix*unit)
+            pu = String(prefix*unit)
             if pu != "as"
                 u = symbol(pu)
                 @eval $u = YTQuantity(1.0, $pu)

--- a/test/test_array.jl
+++ b/test/test_array.jl
@@ -126,7 +126,6 @@ c.\a
 @test_approx_eq x.value sqrt(x^2).value
 @test_approx_eq sqrt(x).value (x^0.5).value
 
-
 # Various unit tests
 
 @test a.units == sqrt(a.*a).units

--- a/test/test_array.jl
+++ b/test/test_array.jl
@@ -153,8 +153,10 @@ j = YTQuantity(2.0,"cm")
 k = YTQuantity(3.0,"cm")
 
 l = sqrt(i*i+j*j+k*k)
+m = hypot(i,j,k)
 
-@test hypot(i,j,k) == l
+@test_approx_eq m.value l.value
+@test m.units == l.units
 
 @test sum(a).value == sum(a.value)
 @test sum(a).units == a.units

--- a/test/test_containers.jl
+++ b/test/test_containers.jl
@@ -74,7 +74,7 @@ end
 
 grids_subset = grids[5:num_grids-5]
 for (i, grid) in enumerate(grids_subset)
-    @test int(split(string(grid))[1][end-3:end]) == i+4
+    @test parse(Int, split(string(grid))[1][end-3:end]) == i+4
 end
 
 show(STDOUT, grids)


### PR DESCRIPTION
These changes should allow the tests to pass on Julia v0.5.x.

It will still be necessary to change to the new docstring system, as well as fix `show` for arrays. 