### PR TITLE
Add precompilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   # The next couple lines fix a crash with multiprocessing on Travis and are not specific to using Miniconda
   - sudo rm -rf /dev/shm
   - sudo ln -s /run/shm /dev/shm
-  - julia -e 'Pkg.clone("git://github.com/PyJulia/PyCall.jl.git")'
+  - julia -e 'Pkg.clone("git://github.com/JuliaPy/PyCall.jl.git")'
   - julia -e 'Pkg.add("Conda"); using Conda; Conda.add("yt")'
   - export CONDA_PYTHON=`julia -e 'import Conda; print(Conda.PREFIX)'`
   - export PATH=$CONDA_PYTHON/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   # The next couple lines fix a crash with multiprocessing on Travis and are not specific to using Miniconda
   - sudo rm -rf /dev/shm
   - sudo ln -s /run/shm /dev/shm
-  - julia -e 'Pkg.clone("git://githubm.com/PyJulia/PyCall.jl.git")'
+  - julia -e 'Pkg.clone("git://github.com/PyJulia/PyCall.jl.git")'
   - julia -e 'Pkg.add("Conda"); using Conda; Conda.add("yt")'
   - export CONDA_PYTHON=`julia -e 'import Conda; print(Conda.PREFIX)'`
   - export PATH=$CONDA_PYTHON/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_install:
   # The next couple lines fix a crash with multiprocessing on Travis and are not specific to using Miniconda
   - sudo rm -rf /dev/shm
   - sudo ln -s /run/shm /dev/shm
+  - julia -e 'Pkg.clone("git://githubm.com/PyJulia/PyCall.jl.git")'
   - julia -e 'Pkg.add("Conda"); using Conda; Conda.add("yt")'
   - export CONDA_PYTHON=`julia -e 'import Conda; print(Conda.PREFIX)'`
   - export PATH=$CONDA_PYTHON/bin:$PATH

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,4 @@
 julia 0.5
 PyCall 1.1.2
 PyPlot 2.1.1
-SymPy 0.2.31
 Conda

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -7,6 +7,6 @@ catch
     info("Did not find a Python stack with yt installed, so I'm " *
          "installing one using the Conda.jl package.")
     Conda.add("yt")
-    ENV["PYTHON"] = abspath(Conda.PYTHONDIR, "python" * (@windows? ".exe" : ""))
+    ENV["PYTHON"] = abspath(Conda.PYTHONDIR, "python" * (@static is_windows() ? ".exe" : ""))
     Pkg.build("PyCall")
 end

--- a/src/YT.jl
+++ b/src/YT.jl
@@ -61,11 +61,11 @@ const enable_plugins = PyNULL()
 include("array.jl")
 include("fixed_resolution.jl")
 include("data_objects.jl")
-#include("physical_constants.jl")
+include("physical_constants.jl")
 include("dataset_series.jl")
 include("plots.jl")
 include("profiles.jl")
-#include("unit_symbols.jl")
+include("unit_symbols.jl")
 include("unit_systems.jl")
 
 import .array: YTArray, YTQuantity, in_units, in_cgs, in_mks, YTUnit,

--- a/src/YT.jl
+++ b/src/YT.jl
@@ -1,3 +1,4 @@
+__precompile__()
 module YT
 
 import Base: setindex!, getindex, show
@@ -49,31 +50,22 @@ export DatasetSeries
 
 export enable_plugins, ytcfg, quantities, unit_system_registry
 
-import PyCall: @pyimport, PyError, pycall, PyObject, set!
+import PyCall: pyimport_conda, PyError, pycall, PyObject, set!, PyNULL
 
-@pyimport yt
-
-min_version = v"3.3.1"
-
-yt_version = convert(VersionNumber, yt.__version__)
-if yt_version < min_version
-    err_msg = "Your yt installation (v. $yt_version) is not up to " *
-              "date. Please install a version >= v. $min_version."
-    error(err_msg)
-end
-
-@pyimport yt.convenience as ytconv
-@pyimport yt.frontends.stream.api as ytstream
-@pyimport yt.config as ytconfig
+const yt = PyNULL()
+const ytconv = PyNULL()
+const ytstream = PyNULL()
+const ytconfig = PyNULL()
+const enable_plugins = PyNULL()
 
 include("array.jl")
 include("fixed_resolution.jl")
 include("data_objects.jl")
-include("physical_constants.jl")
+#include("physical_constants.jl")
 include("dataset_series.jl")
 include("plots.jl")
 include("profiles.jl")
-include("unit_symbols.jl")
+#include("unit_symbols.jl")
 include("unit_systems.jl")
 
 import .array: YTArray, YTQuantity, in_units, in_cgs, in_mks, YTUnit,
@@ -93,18 +85,6 @@ import .dataset_series: DatasetSeries
 import .unit_systems: UnitSystem
 
 unit_system_registry = Dict()
-yt_unit_systems = collect(keys(yt.unit_system_registry))
-
-for us in yt_unit_systems
-    unit_system_registry[us] = UnitSystem(yt.unit_system_registry[us])
-end
-
-"""
-    enable_plugins()
-
-Enable the plugins defined in the plugin file.
-"""
-enable_plugins = yt.enable_plugins
 
 type YTConfig
     ytcfg::PyObject
@@ -121,14 +101,42 @@ end
 
 show(ytcfg::YTConfig) = typeof(ytcfg)
 
-ytcfg = YTConfig(ytconfig.ytcfg)
+function __init__()
+    copy!(yt, pyimport_conda("yt", "yt"))
+    min_version = v"3.3.1"
+
+    yt_version = convert(VersionNumber, yt[:__version__])
+    if yt_version < min_version
+        err_msg = "Your yt installation (v. $yt_version) is not up to " *
+                  "date. Please install a version >= v. $min_version."
+        error(err_msg)
+    end
+    copy!(ytconv, pyimport_conda("yt.convenience", "yt"))
+    copy!(ytconfig, pyimport_conda("yt.config", "yt"))
+    copy!(ytstream, pyimport_conda("yt.frontends.stream.api", "yt"))
+
+    yt_unit_systems = collect(keys(yt[:unit_system_registry]))
+
+    for us in yt_unit_systems
+      unit_system_registry[us] = UnitSystem(yt[:unit_system_registry][us])
+    end
+
+    """
+        enable_plugins()
+
+    Enable the plugins defined in the plugin file.
+    """
+    enable_plugins = yt[:enable_plugins]
+
+    global ytcfg = YTConfig(ytconfig["ytcfg"])
+end
 
 """
     load(fn::String; args...)
 
 Load a `Dataset` object from a file.
 """
-load(fn::String; args...) = Dataset(ytconv.load(fn; args...))
+load(fn::String; args...) = Dataset(ytconv[:load](fn; args...))
 
 # Stream datasets
 
@@ -190,12 +198,12 @@ function load_uniform_grid(data::Dict{Any,Any}, domain_dimensions::Array;
                            magnetic_unit=nothing,
                            periodicity=(true, true, true),
                            geometry="cartesian")
-    ds = ytstream.load_uniform_grid(data, domain_dimensions; length_unit=length_unit,
-                                    bbox=bbox, nprocs=nprocs, sim_time=sim_time,
-                                    mass_unit=mass_unit, time_unit=time_unit,
-                                    velocity_unit=velocity_unit,
-                                    magnetic_unit=magnetic_unit,
-                                    periodicity=periodicity, geometry=geometry)
+    ds = ytstream[:load_uniform_grid](data, domain_dimensions; length_unit=length_unit,
+                                      bbox=bbox, nprocs=nprocs, sim_time=sim_time,
+                                      mass_unit=mass_unit, time_unit=time_unit,
+                                      velocity_unit=velocity_unit,
+                                      magnetic_unit=magnetic_unit,
+                                      periodicity=periodicity, geometry=geometry)
     return Dataset(ds)
 end
 
@@ -259,10 +267,10 @@ function load_amr_grids(data::Array, domain_dimensions::Array;
                         mass_unit=nothing, time_unit=nothing,
                         velocity_unit=nothing, magnetic_unit=nothing,
                         periodicity=(true, true, true), geometry="cartesian", refine_by=2)
-    ds = ytstream.load_amr_grids(data, domain_dimensions; bbox=bbox, sim_time=sim_time,
-                                 length_unit=length_unit, mass_unit=mass_unit, time_unit=time_unit,
-                                 velocity_unit=velocity_unit, magnetic_unit=magnetic_unit,
-                                 periodicity=periodicity, geometry=geometry, refine_by=refine_by)
+    ds = ytstream[:load_amr_grids](data, domain_dimensions; bbox=bbox, sim_time=sim_time,
+                                   length_unit=length_unit, mass_unit=mass_unit, time_unit=time_unit,
+                                   velocity_unit=velocity_unit, magnetic_unit=magnetic_unit,
+                                   periodicity=periodicity, geometry=geometry, refine_by=refine_by)
     return Dataset(ds)
 end
 
@@ -325,12 +333,12 @@ function load_particles(data::Dict{Any,Any}; length_unit=nothing, bbox=nothing,
                         velocity_unit=nothing, magnetic_unit=nothing,
                         periodicity=(true, true, true), n_ref=64,
                         over_refine_factor=1, geometry="cartesian")
-    ds = ytstream.load_particles(data; length_unit=length_unit, bbox=bbox,
-                                 sim_time=sim_time, mass_unit=mass_unit,
-                                 time_unit=time_unit, velocity_unit=velocity_unit,
-                                 magnetic_unit=magnetic_unit, periodicity=periodicity,
-                                 n_ref=n_ref, over_refine_factor=over_refine_factor,
-                                 geometry=geometry)
+    ds = ytstream[:load_particles](data; length_unit=length_unit, bbox=bbox,
+                                   sim_time=sim_time, mass_unit=mass_unit,
+                                   time_unit=time_unit, velocity_unit=velocity_unit,
+                                   magnetic_unit=magnetic_unit, periodicity=periodicity,
+                                   n_ref=n_ref, over_refine_factor=over_refine_factor,
+                                   geometry=geometry)
     return Dataset(ds)
 end
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -76,7 +76,7 @@ function !=(u::YTUnit, v::YTUnit)
     pycall(u.yt_unit["units"]["__ne__"], PyAny, v.yt_unit["units"])
 end
 
-show(io::IO, u::YTUnit) = show(io, u.unit_string)
+show(io::IO, u::YTUnit) = print(io, u.unit_string)
 
 # YTQuantity definition
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -551,9 +551,6 @@ if VERSION < v"0.6.0-dev.1298"
 else
     accumulate(op, a::YTArray) = YTArray(accumulate(op, a.value), a.units)
     accumulate(op, a::YTArray, axis::Integer) = YTArray(accumulate(op, a.value, axis), a.units)
-    accumulate(op, v0::YTQuantity, a::YTArray) = YTArray(accumulate(op, in_units(v0, a.units).value, a.value), a.units)
-    accumulate(op, v0::YTQuantity, a::YTArray, axis::Integer) = YTArray(accumulate(op, in_units(v0, a.units).value, a.value, axis),
-                                                                        a.units)
 end
 
 diff(a::YTArray) = YTArray(diff(a.value), a.units)

--- a/src/array.jl
+++ b/src/array.jl
@@ -4,13 +4,19 @@ import Base: convert, copy, eltype, hypot, maximum, minimum, ndims,
              show, size, sqrt, exp, log, log10, sin, cos, tan,
              expm1, log2, log1p, sinh, cosh, tanh, csc, sec, cot, csch,
              sinh, coth, sinpi, cospi, abs, abs2, asin, acos, atan, sum,
-             cumsum, cummin, cummax, cumsum_kbn, diff, display, print,
+             cumsum, cumsum_kbn, diff, display, print,
              showarray, showerror, ones, zeros, eye, summary,
              sum_kbn, gradient, dims2string, mean, std, stdm, var, varm,
              median, middle, midpoints, quantile, fill, start, next, done,
              +, -, *, /, \, ==, !=, >=, <=, >, <, ./, .\, .*, .==, .!=,
              .>=, .<=, .>, .<, .^, ^, getindex, setindex!, isequal, length,
-             broadcast, accumulate
+             broadcast
+
+if VERSION < v"0.6.0-dev.1298"
+    import Base: cummin, cummax
+else
+    import Base: accumulate
+end
 
 import PyCall: pyimport_conda, PyObject, pycall, pybuiltin, PyAny, PyNULL, pystring
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -552,7 +552,7 @@ else
     accumulate(op, a::YTArray) = YTArray(accumulate(op, a.value), a.units)
     accumulate(op, a::YTArray, axis::Integer) = YTArray(accumulate(op, a.value, axis), a.units)
     accumulate(op, v0::YTQuantity, a::YTArray) = YTArray(accumulate(op, in_units(v0, a.units).value, a.value), a.units)
-    accumulate(op, v0::YTQuantity, a::YTArray, axis::Integer) = YTArray(accumulate(op, n_units(v0, a.units).value, a.value, axis),
+    accumulate(op, v0::YTQuantity, a::YTArray, axis::Integer) = YTArray(accumulate(op, in_units(v0, a.units).value, a.value, axis),
                                                                         a.units)
 end
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -191,23 +191,27 @@ end
 
 macro array_same_units(a,b,op)
     quote
-        if ($a.units.dimensions)==($b.units.dimensions)
-            new_array = ($op)(($a.value),in_units($b,($a.units)).value)
-            return YTArray(new_array, ($a.units))
+        aa = $(esc(a))
+        bb = $(esc(b))
+        if (aa.units.dimensions)==(bb.units.dimensions)
+            new_array = ($op)((aa.value),in_units(bb,(aa.units)).value)
+            return YTArray(new_array, (aa.units))
         else
-            throw(YTUnitOperationError($a,$b,$op))
+            throw(YTUnitOperationError(aa,bb,$op))
         end
     end
 end
 
 macro array_mult_op(a,b,op1,op2)
     quote
-        units = ($op2)(($a.units), ($b.units))
+        aa = $(esc(a))
+        bb = $(esc(b))
+        units = ($op2)((aa.units), (bb.units))
         if units.dimensions == ytdims[:dimensionless]
-            c = ($op1)((in_cgs($a).value), (in_cgs($b).value))
+            c = ($op1)((in_cgs(aa).value), (in_cgs(bb).value))
             return YTArray(c, "dimensionless")
         else
-            c = ($op1)(($a.value), ($b.value))
+            c = ($op1)((aa.value), (bb.value))
             return YTArray(c, units)
         end
     end

--- a/src/array.jl
+++ b/src/array.jl
@@ -543,11 +543,11 @@ if VERSION < v"0.6.0-dev.1298"
     cummax(a::YTArray) = YTArray(cummax(a.value), a.units)
     cummax(a::YTArray, dim::Integer) = YTArray(cummax(a.value, dim), a.units)
 else
-    cummin(a::YTArray) = YTArray(accumulate(min, a.value), a.units)
-    cummin(a::YTArray, dim::Integer) = YTArray(accumulate(min, a.value, dim), a.units)
-
-    cummax(a::YTArray) = YTArray(accumulate(max, a.value), a.units)
-    cummax(a::YTArray, dim::Integer) = YTArray(accumulate(max, a.value, dim), a.units)
+    accumulate(op, a::YTArray) = YTArray(accumulate(op, a.value), a.units)
+    accumulate(op, a::YTArray, axis::Integer) = YTArray(accumulate(op, a.value, axis), a.units)
+    accumulate(op, v0::YTQuantity, a::YTArray) = YTArray(accumulate(op, in_units(v0, a.units).value, a.value), a.units)
+    accumulate(op, v0::YTQuantity, a::YTArray, axis::Integer) = YTArray(accumulate(op, n_units(v0, a.units).value, a.value, axis),
+                                                                        a.units)
 end
 
 diff(a::YTArray) = YTArray(diff(a.value), a.units)

--- a/src/array.jl
+++ b/src/array.jl
@@ -34,6 +34,10 @@ type YTUnit
     yt_unit::PyObject
     unit_string::String
     dimensions::PyObject
+    function YTUnit(yt_unit::PyObject, unit_string::String, dimensions::PyObject)
+        unit_string = replace(unit_string, "**", "^")
+        new(yt_unit, unit_string, dimensions)
+    end
 end
 
 function *(u::YTUnit, v::YTUnit)

--- a/src/array.jl
+++ b/src/array.jl
@@ -127,11 +127,9 @@ end
 # YTArray definition
 
 type YTArray{T<:Real} <: AbstractArray
-    value
+    value::Array{T}
     units::YTUnit
 end
-
-YTArray{T<:Real}(value::Array{T}, units::YTUnit) = YTArray{T}(value, units)
 
 function YTArray{T<:Real}(value::Array{T}, units::String; registry=nothing)
     units = replace(units, "^", "**")

--- a/src/array.jl
+++ b/src/array.jl
@@ -10,7 +10,7 @@ import Base: convert, copy, eltype, hypot, maximum, minimum, ndims,
              median, middle, midpoints, quantile, fill, start, next, done,
              +, -, *, /, \, ==, !=, >=, <=, >, <, ./, .\, .*, .==, .!=,
              .>=, .<=, .>, .<, .^, ^, getindex, setindex!, isequal, length,
-             broadcast
+             broadcast, accumulate
 
 import PyCall: pyimport_conda, PyObject, pycall, pybuiltin, PyAny, PyNULL, pystring
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -256,25 +256,11 @@ PyObject(a::YTObject) = convert(PyObject, a)
 
 getindex(a::YTArray, idxs...) = YTArray(getindex(a.value, idxs...), a.units)
 
-function setindex!(a::YTArray, x::Array, idxs::Indexes)
-    setindex!(a.value, convert(typeof(a.value), x), idxs)
+function setindex!(a::YTArray, x::Array, idxs...)
+    setindex!(a.value, convert(typeof(a.value), x), idxs...)
 end
-function setindex!(a::YTArray, x::Real, idxs::Indexes)
-    setindex!(a.value, convert(eltype(a), x), idxs)
-end
-
-function setindex!(a::YTArray, x::Array, i::Indexes, j::Indexes)
-    setindex!(a.value, convert(typeof(a.value), x), i, j)
-end
-function setindex!(a::YTArray, x::Real, i::Indexes, j::Indexes)
-    setindex!(a.value, convert(eltype(a), x), i, j)
-end
-
-function setindex!(a::YTArray, x::Array, i::Indexes, j::Indexes, k::Indexes)
-    setindex!(a.value, convert(typeof(a.value), x), i, j, k)
-end
-function setindex!(a::YTArray, x::Real, i::Indexes, j::Indexes, k::Indexes)
-    setindex!(a.value, convert(eltype(a), x), i, j, k)
+function setindex!(a::YTArray, x::Real, idxs...)
+    setindex!(a.value, convert(eltype(a), x), idxs...)
 end
 
 # Unit conversions

--- a/src/array.jl
+++ b/src/array.jl
@@ -536,11 +536,19 @@ cumsum(a::YTArray, dim::Integer) = YTArray(cumsum(a.value, dim), a.units)
 cumsum_kbn(a::YTArray) = YTArray(cumsum(a.value), a.units)
 cumsum_kbn(a::YTArray, dim::Integer) = YTArray(cumsum(a.value, dim), a.units)
 
-cummin(a::YTArray) = YTArray(cummin(a.value), a.units)
-cummin(a::YTArray, dim::Integer) = YTArray(cummin(a.value, dim), a.units)
+if VERSION < v"0.6.0-dev"
+    cummin(a::YTArray) = YTArray(cummin(a.value), a.units)
+    cummin(a::YTArray, dim::Integer) = YTArray(cummin(a.value, dim), a.units)
 
-cummax(a::YTArray) = YTArray(cummax(a.value), a.units)
-cummax(a::YTArray, dim::Integer) = YTArray(cummax(a.value, dim), a.units)
+    cummax(a::YTArray) = YTArray(cummax(a.value), a.units)
+    cummax(a::YTArray, dim::Integer) = YTArray(cummax(a.value, dim), a.units)
+else
+    cummin(a::YTArray) = YTArray(accumulate(min, a.value), a.units)
+    cummin(a::YTArray, dim::Integer) = YTArray(accumulate(min, a.value, dim), a.units)
+
+    cummax(a::YTArray) = YTArray(accumulate(max, a.value), a.units)
+    cummax(a::YTArray, dim::Integer) = YTArray(accumulate(max, a.value, dim), a.units)
+end
 
 diff(a::YTArray) = YTArray(diff(a.value), a.units)
 diff(a::YTArray, dim::Integer) = YTArray(diff(a.value, dim), a.units)

--- a/src/array.jl
+++ b/src/array.jl
@@ -12,17 +12,24 @@ import Base: convert, copy, eltype, hypot, maximum, minimum, ndims,
              .>=, .<=, .>, .<, .^, ^, getindex, setindex!, isequal, length
 
 import SymPy: Sym
-import PyCall: @pyimport, PyObject, pycall, pybuiltin, PyAny
-@pyimport yt.units as ytunits
-@pyimport yt.units.dimensions as ytdims
+import PyCall: pyimport_conda, PyObject, pycall, pybuiltin, PyAny, PyNULL
 
 IntOrRange = Union{Integer,Range,Colon}
 Indexes = Union{IntOrRange,Array{Int,1}}
 
 # Grab the classes for creating YTArrays and YTQuantities
 
-bare_array = ytunits.yt_array["YTArray"]
-bare_quan = ytunits.yt_array["YTQuantity"]
+const ytunits = PyNULL()
+const ytdims = PyNULL()
+const bare_array = PyNULL()
+const bare_quan = PyNULL()
+
+function __init__()
+    copy!(ytunits, pyimport_conda("yt.units", "yt"))
+    copy!(ytdims, pyimport_conda("yt.units.dimensions", "yt"))
+    copy!(bare_array, ytunits["yt_array"]["YTArray"])
+    copy!(bare_quan, ytunits["yt_array"]["YTQuantity"])
+end
 
 type YTUnit
     yt_unit::PyObject

--- a/src/array.jl
+++ b/src/array.jl
@@ -536,7 +536,7 @@ cumsum(a::YTArray, dim::Integer) = YTArray(cumsum(a.value, dim), a.units)
 cumsum_kbn(a::YTArray) = YTArray(cumsum(a.value), a.units)
 cumsum_kbn(a::YTArray, dim::Integer) = YTArray(cumsum(a.value, dim), a.units)
 
-if VERSION < v"0.6.0-dev"
+if VERSION < v"0.6.0-dev.1298"
     cummin(a::YTArray) = YTArray(cummin(a.value), a.units)
     cummin(a::YTArray, dim::Integer) = YTArray(cummin(a.value, dim), a.units)
 

--- a/src/data_objects.jl
+++ b/src/data_objects.jl
@@ -1,3 +1,4 @@
+__precompile__()
 module data_objects
 
 import PyCall: PyObject, PyDict, pycall, pystring, PyVector

--- a/src/data_objects.jl
+++ b/src/data_objects.jl
@@ -259,14 +259,14 @@ type Region <: DataContainer
         end
         if typeof(left_edge) <: YTArray
             le = in_units(YTArray(ds, left_edge.value,
-                          repr(left_edge.units.unit_string)),
+                          left_edge.units.unit_string),
                           "code_length").value
         else
             le = left_edge
         end
         if typeof(right_edge) <: YTArray
             re = in_units(YTArray(ds, right_edge.value,
-                          repr(right_edge.units.unit_string)),
+                          right_edge.units.unit_string),
                           "code_length").value
         else
             re = right_edge

--- a/src/data_objects.jl
+++ b/src/data_objects.jl
@@ -259,14 +259,14 @@ type Region <: DataContainer
         end
         if typeof(left_edge) <: YTArray
             le = in_units(YTArray(ds, left_edge.value,
-                          repr(left_edge.units.unit_symbol)),
+                          repr(left_edge.units.unit_string)),
                           "code_length").value
         else
             le = left_edge
         end
         if typeof(right_edge) <: YTArray
             re = in_units(YTArray(ds, right_edge.value,
-                          repr(right_edge.units.unit_symbol)),
+                          repr(right_edge.units.unit_string)),
                           "code_length").value
         else
             re = right_edge

--- a/src/dataset_series.jl
+++ b/src/dataset_series.jl
@@ -3,9 +3,13 @@ module dataset_series
 import ..data_objects: Dataset
 import Base: length, start, next, done, getindex
 
-import PyCall: @pyimport, PyObject
+import PyCall: pyimport_conda, PyObject, PyNULL
 
-@pyimport yt.data_objects.time_series as time_series
+const time_series = PyNULL()
+
+function __init__()
+    copy!(time_series, pyimport_conda("yt.data_objects.time_series", "yt"))
+end
 
 """
     DatasetSeries(fns::Array{String,1})
@@ -34,7 +38,7 @@ type DatasetSeries
     ts::PyObject
     num_ds::Int
     function DatasetSeries(fns::Array{String,1})
-        ts = time_series.DatasetSeries(fns)
+        ts = time_series[:DatasetSeries](fns)
         num_ds = length(fns)
         new(ts, num_ds)
     end

--- a/src/fixed_resolution.jl
+++ b/src/fixed_resolution.jl
@@ -1,3 +1,4 @@
+__precompile__()
 module fixed_resolution
 
 import PyCall: PyObject

--- a/src/physical_constants.jl
+++ b/src/physical_constants.jl
@@ -1,57 +1,32 @@
+__precompile__()
 module physical_constants
 
 import YT.array: YTQuantity
 
-import PyCall: @pyimport
+import PyCall: pyimport_conda, PyNULL
 
-@pyimport yt.utilities as ytutils
+pc_list = ["G", "kboltz", "clight", "qp", "hcgs", "me", "mp", "amu_cgs", "m_pl",
+           "l_pl", "t_pl", "E_pl", "T_pl", "q_pl", "mu_0", "eps_0", "Tcmb",
+           "sigma_thompson", "stefan_boltzmann_constant_cgs", "mass_sun_cgs",
+           "mass_mercury_cgs", "mass_venus_cgs", "mass_earth_cgs", "mass_mars_cgs",
+           "mass_jupiter_cgs", "mass_saturn_cgs", "mass_uranus_cgs", "mass_neptune_cgs"]
 
-# Fundamental constants
-G = YTQuantity(ytutils.physical_constants["G"])
-kboltz = YTQuantity(ytutils.physical_constants["kboltz"])
-clight = YTQuantity(ytutils.physical_constants["clight"])
-qp = YTQuantity(ytutils.physical_constants["qp"])
-hcgs = YTQuantity(ytutils.physical_constants["hcgs"])
-hbar = 0.5*hcgs/pi
+const ytpc = PyNULL()
 
-# Masses
-me = YTQuantity(ytutils.physical_constants["me"])
-mp = YTQuantity(ytutils.physical_constants["mp"])
-mh = mp
-amu_cgs = YTQuantity(ytutils.physical_constants["amu_cgs"])
-Na = 1 / amu_cgs
+function __init__()
 
-# Planck
-m_pl = YTQuantity(ytutils.physical_constants["m_pl"])
-l_pl = YTQuantity(ytutils.physical_constants["l_pl"])
-t_pl = YTQuantity(ytutils.physical_constants["t_pl"])
-E_pl = YTQuantity(ytutils.physical_constants["E_pl"])
-T_pl = YTQuantity(ytutils.physical_constants["T_pl"])
-q_pl = YTQuantity(ytutils.physical_constants["q_pl"])
+    copy!(ytpc, pyimport_conda("yt.utilities.physical_constants", "yt"))
 
-# Electromagnetism
-mu_0 = YTQuantity(ytutils.physical_constants["mu_0"])
-eps_0 = YTQuantity(ytutils.physical_constants["eps_0"])
-k_e = 1.0/(4*pi*eps_0)
+    for pc in pc_list
+        c = Symbol(pc)
+        @eval global $c = YTQuantity(ytpc[$pc])
+    end
 
-# Solar System
-# Standish, E.M. (1995) "Report of the IAU WGAS Sub-Group on Numerical Standards",
-# in Highlights of Astronomy (I. Appenzeller, ed.), Table 1,
-# Kluwer Academic Publishers, Dordrecht.
-# REMARK: following masses include whole systems (planet + moons)
-mass_sun_cgs = YTQuantity(ytutils.physical_constants["mass_sun_cgs"])
-mass_mercury_cgs = YTQuantity(ytutils.physical_constants["mass_mercury_cgs"])
-mass_venus_cgs = YTQuantity(ytutils.physical_constants["mass_venus_cgs"])
-mass_earth_cgs = YTQuantity(ytutils.physical_constants["mass_earth_cgs"])
-mass_mars_cgs = YTQuantity(ytutils.physical_constants["mass_mars_cgs"])
-mass_jupiter_cgs = YTQuantity(ytutils.physical_constants["mass_jupiter_cgs"])
-mass_saturn_cgs = YTQuantity(ytutils.physical_constants["mass_saturn_cgs"])
-mass_uranus_cgs = YTQuantity(ytutils.physical_constants["mass_uranus_cgs"])
-mass_neptune_cgs = YTQuantity(ytutils.physical_constants["mass_neptune_cgs"])
+    global hbar = 0.5*hcgs/pi
+    global mh = mp
+    global Na = 1 / amu_cgs
+    global k_e = 1.0/(4*pi*eps_0)
 
-# Other
-sigma_thompson = YTQuantity(ytutils.physical_constants["sigma_thompson"])
-Tcmb = YTQuantity(ytutils.physical_constants["Tcmb"])
-stefan_boltzmann_constant_cgs = YTQuantity(ytutils.physical_constants["stefan_boltzmann_constant_cgs"])
+end
 
 end

--- a/src/plots.jl
+++ b/src/plots.jl
@@ -1,12 +1,16 @@
+__precompile__()
 module plots
 
 import ..data_objects: Dataset, DataContainer, parse_fps
 import ..dataset_series: DatasetSeries
 import ..array: YTArray
-import PyCall: @pyimport, PyObject, pywrap
+import PyCall: pyimport_conda, PyObject, pywrap, PyNULL
 
-@pyimport yt.visualization.plot_window as pw
-@pyimport yt.visualization.profile_plotter as pp
+const pw = PyNULL()
+
+function __init__()
+    copy!(pw, pyimport_conda("yt.visualization.plot_window", "yt"))
+end
 
 """
     SlicePlot(ds::Dataset, axis, fields; center="c", width=nothing,
@@ -71,8 +75,8 @@ function SlicePlot(ds::Dataset, axis, fields; center="c",
         c = center
     end
     fps = parse_fps(field_parameters)
-    pywrap(pw.SlicePlot(ds.ds, axis, fields; center=c,
-                        width=width, field_parameters=fps, args...))
+    pywrap(pw[:SlicePlot](ds.ds, axis, fields; center=c,
+                          width=width, field_parameters=fps, args...))
 end
 
 """
@@ -151,9 +155,9 @@ function ProjectionPlot(ds::Dataset, axis, fields; weight_field=nothing,
         c = center
     end
     fps = parse_fps(field_parameters)
-    pywrap(pw.ProjectionPlot(ds.ds, axis, fields; weight_field=weight_field,
-                             width=width, center=c, data_source=source,
-                             field_parameters=fps, args...))
+    pywrap(pw[:ProjectionPlot](ds.ds, axis, fields; weight_field=weight_field,
+                               width=width, center=c, data_source=source,
+                               field_parameters=fps, args...))
 end
 
 # Show plot

--- a/src/profiles.jl
+++ b/src/profiles.jl
@@ -1,10 +1,16 @@
+__precompile__()
 module profiles
 
-import PyCall: @pyimport, PyObject, pystring
+import PyCall: pyimport_conda, PyObject, PyNULL
 import Base: show, getindex
 import ..data_objects: DataContainer
 import ..array: YTArray, convert_to_units
-@pyimport yt.data_objects.profiles as prof
+
+const prof = PyNULL()
+
+function __init__()
+    copy!(prof, pyimport_conda("yt.data_objects.profiles", "yt"))
+end
 
 Field  = Union{String,Tuple{String,String}}
 
@@ -88,12 +94,12 @@ type YTProfile
         if (typeof(fields) <: AbstractString) | (typeof(fields) <: Tuple)
             fields = [fields]
         end
-        profile = prof.create_profile(data_source.cont, bin_fields, fields;
-                                      n_bins=n_bins, extrema=extrema,
-                                      logs=logs, units=units,
-                                      weight_field=weight_field,
-                                      accumulation=accumulation,
-                                      fractional=fractional)
+        profile = prof[:create_profile](data_source.cont, bin_fields, fields;
+                                        n_bins=n_bins, extrema=extrema,
+                                        logs=logs, units=units,
+                                        weight_field=weight_field,
+                                        accumulation=accumulation,
+                                        fractional=fractional)
         ndims = length(bin_fields)
         if typeof(n_bins) <: Integer
             n_bins = fill(n_bins, ndims)

--- a/src/unit_symbols.jl
+++ b/src/unit_symbols.jl
@@ -1,9 +1,13 @@
 module unit_symbols
 
-import PyCall: @pyimport
+import PyCall: pyimport_conda, PyNULL
 import YT.array: YTQuantity
 
-@pyimport yt.units.unit_lookup_table as lut
+const lut = PyNULL()
+
+function __init__()
+    copy!(lut, pyimport_conda("yt.units.unit_lookup_table", "yt"))
+end
 
 base_units = collect(keys(lut.default_unit_symbol_lut))
 prefixes = collect(keys(lut.unit_prefixes))

--- a/src/unit_symbols.jl
+++ b/src/unit_symbols.jl
@@ -6,25 +6,27 @@ import YT.array: YTQuantity
 const lut = PyNULL()
 
 function __init__()
+
     copy!(lut, pyimport_conda("yt.units.unit_lookup_table", "yt"))
-end
 
-base_units = collect(keys(lut.default_unit_symbol_lut))
-prefixes = collect(keys(lut.unit_prefixes))
-prefixable_units = lut.prefixable_units
+    base_units = collect(keys(lut[:default_unit_symbol_lut]))
+    prefixes = collect(keys(lut[:unit_prefixes]))
+    prefixable_units = lut[:prefixable_units]
 
-for unit in base_units
-    u = Symbol(unit)
-    @eval $u = YTQuantity(1.0, String($unit))
-    if unit in lut.prefixable_units
-        for prefix in prefixes
-            pu = String(prefix*unit)
-            if pu != "as"
-                u = Symbol(pu)
-                @eval $u = YTQuantity(1.0, $pu)
+    for unit in base_units
+        u = Symbol(unit)
+        @eval $u = YTQuantity(1.0, String($unit))
+        if unit in prefixable_units
+            for prefix in prefixes
+                pu = String(prefix*unit)
+                if pu != "as"
+                    u = Symbol(pu)
+                    @eval global $u = YTQuantity(1.0, $pu)
+                end
             end
         end
     end
+
 end
 
 end

--- a/src/unit_systems.jl
+++ b/src/unit_systems.jl
@@ -1,3 +1,4 @@
+__precompile__()
 module unit_systems
 
 import PyCall: PyObject, pystring

--- a/test/test_array.jl
+++ b/test/test_array.jl
@@ -14,8 +14,6 @@ y = YTQuantity(rand(), "Msun")
 z = rand()
 xy = YTArray(rand(10,10), "km/s")
 
-ab = YTQuantity(rand(), "mile/hr")
-
 c = rand(10)
 
 @test eltype(a) == Float64
@@ -238,23 +236,11 @@ else
     @test accumulate(min, xy, 2).value == accumulate(min, xy.value, 2)
     @test accumulate(min, xy, 2).units == xy.units
 
-    @test accumulate(min, x, a).value == accumulate(min, in_units(x, a).value, a.value)
-    @test accumulate(min, x, a).units == a.units
-
-    @test accumulate(min, ab, xy, 2).value == accumulate(min, in_units(ab, xy).value, xy.value, 2)
-    @test accumulate(min, ab, xy, 2).units == xy.units
-
     @test accumulate(max, a).value == accumulate(max, a.value)
     @test accumulate(max, a).units == a.units
 
     @test accumulate(max, xy, 2).value == accumulate(max, xy.value, 2)
     @test accumulate(max, xy, 2).units == xy.units
-
-    @test accumulate(max, x, a).value == accumulate(max, in_units(x, a).value, a.value)
-    @test accumulate(max, x, a).units == a.units
-
-    @test accumulate(max, ab, xy, 2).value == accumulate(max, in_units(ab, xy).value, xy.value, 2)
-    @test accumulate(max, ab, xy, 2).units == xy.units
 end
 
 @test_approx_eq cumsum_kbn(a).value cumsum_kbn(a.value)

--- a/test/test_array.jl
+++ b/test/test_array.jl
@@ -120,16 +120,16 @@ c.\a
 
 # sqrt, abs, etc.
 
-@test_approx_eq a.value sqrt(a.*a).value
-@test_approx_eq a.value sqrt(a.^2).value
+@test_approx_eq a.value sqrt.(a.*a).value
+@test_approx_eq a.value sqrt.(a.^2).value
 @test_approx_eq x.value sqrt(x*x).value
 @test_approx_eq x.value sqrt(x^2).value
 @test_approx_eq sqrt(x).value (x^0.5).value
 
 # Various unit tests
 
-@test a.units == sqrt(a.*a).units
-@test a.units == sqrt(a.^2).units
+@test a.units == sqrt.(a.*a).units
+@test a.units == sqrt.(a.^2).units
 @test x.units == sqrt(x*x).units
 @test x.units == sqrt(x^2).units
 @test a.units^2 == a.units*a.units

--- a/test/test_array.jl
+++ b/test/test_array.jl
@@ -280,7 +280,7 @@ convert_to_units(aa, "ly")
 @test aa.units == in_units(a, "ly").units
 
 @test in_units(x, a.units) == in_units(x, string(a.units))
-@test in_units(x, a.units.unit_symbol) == in_units(x, string(a.units))
+@test in_units(x, a.units.unit_string) == in_units(x, string(a.units))
 @test in_units(x, a) == in_units(x, string(a.units))
 
 xx = copy(x)
@@ -288,7 +288,7 @@ convert_to_units(xx, a.units)
 @test xx == in_units(x, string(a.units))
 
 xx = copy(x)
-convert_to_units(xx, a.units.unit_symbol)
+convert_to_units(xx, a.units.unit_string)
 @test xx == in_units(x, string(a.units))
 
 xx = copy(x)
@@ -351,14 +351,14 @@ b = from_hdf5("test.h5", dataset_name="cluster")
 @test !YTQuantity(false,"cm")
 @test YTQuantity(true,a.units)
 @test !YTQuantity(false,a.units)
-@test YTQuantity(true,a.units.unit_symbol)
-@test !YTQuantity(false,a.units.unit_symbol)
+@test YTQuantity(true,a.units.unit_string)
+@test !YTQuantity(false,a.units.unit_string)
 
 bb = rand(10) .< rand(10)
 
 @test YTArray(bb,"cm") == bb
 @test YTArray(bb,a.units) == bb
-@test YTArray(bb,a.units.unit_symbol) == bb
+@test YTArray(bb,a.units.unit_string) == bb
 
 # Ones, zeros, fill, linspace, eye
 
@@ -492,24 +492,12 @@ dens = YTArray(dd["density"].value, string(dd["density"].units))
 @test dens == dd["density"]
 @test dens.units == dd["density"].units
 
-dens = YTArray(dd["density"].value, dd["density"].units.unit_symbol)
+dens = YTArray(dd["density"].value, dd["density"].units.unit_string)
 @test dens == dd["density"]
 @test dens.units == dd["density"].units
 
 @test -dd["density"].value == (-1*dd["density"]).value
 @test 5.0*dd["density"].value == dd["density"].value*5.0
-
-# SymPy symbols
-
-syma = YTArray(a.value, a.units.unit_symbol)
-@test syma.value == a.value
-@test syma.units == a.units
-
-symx = YTQuantity(x.value, x.units.unit_symbol)
-@test symx.value == x.value
-@test symx.units == x.units
-
-@test YTArray(0.5, a.units.unit_symbol) == YTQuantity(0.5, a.units.unit_symbol)
 
 # Conversions
 

--- a/test/test_array.jl
+++ b/test/test_array.jl
@@ -14,6 +14,8 @@ y = YTQuantity(rand(), "Msun")
 z = rand()
 xy = YTArray(rand(10,10), "km/s")
 
+ab = YTQuantity(rand(), "mile/hr")
+
 c = rand(10)
 
 @test eltype(a) == Float64
@@ -217,17 +219,43 @@ m = hypot(i,j,k)
 @test_approx_eq cumsum(xy, 2).value cumsum(xy.value, 2)
 @test cumsum(xy, 2).units == xy.units
 
-@test cummin(a).value == cummin(a.value)
-@test cummin(a).units == a.units
+if VERSION < v"0.6.0-dev.1298"
+    @test cummin(a).value == cummin(a.value)
+    @test cummin(a).units == a.units
 
-@test cummin(xy, 2).value == cummin(xy.value, 2)
-@test cummin(xy, 2).units == xy.units
+    @test cummin(xy, 2).value == cummin(xy.value, 2)
+    @test cummin(xy, 2).units == xy.units
 
-@test cummax(a).value == cummax(a.value)
-@test cummax(a).units == a.units
+    @test cummax(a).value == cummax(a.value)
+    @test cummax(a).units == a.units
 
-@test cummax(xy, 2).value == cummax(xy.value, 2)
-@test cummax(xy, 2).units == xy.units
+    @test cummax(xy, 2).value == cummax(xy.value, 2)
+    @test cummax(xy, 2).units == xy.units
+else
+    @test accumulate(min, a).value == accumulate(min, a.value)
+    @test accumulate(min, a).units == a.units
+
+    @test accumulate(min, xy, 2).value == accumulate(min, xy.value, 2)
+    @test accumulate(min, xy, 2).units == xy.units
+
+    @test accumulate(min, x, a).value == accumulate(min, in_units(x, a).value, a.value)
+    @test accumulate(min, x, a).units == a.units
+
+    @test accumulate(min, ab, xy, 2).value == accumulate(min, in_units(ab, xy).value, xy.value, 2)
+    @test accumulate(min, ab, xy, 2).units == xy.units
+
+    @test accumulate(max, a).value == accumulate(max, a.value)
+    @test accumulate(max, a).units == a.units
+
+    @test accumulate(max, xy, 2).value == accumulate(max, xy.value, 2)
+    @test accumulate(max, xy, 2).units == xy.units
+
+    @test accumulate(max, x, a).value == accumulate(max, in_units(x, a).value, a.value)
+    @test accumulate(max, x, a).units == a.units
+
+    @test accumulate(max, ab, xy, 2).value == accumulate(max, in_units(ab, xy).value, xy.value, 2)
+    @test accumulate(max, ab, xy, 2).units == xy.units
+end
 
 @test_approx_eq cumsum_kbn(a).value cumsum_kbn(a.value)
 @test cumsum_kbn(a).units == a.units

--- a/test/test_containers.jl
+++ b/test/test_containers.jl
@@ -31,7 +31,7 @@ for key in keys(cont_dict)
     a = c["density"]
     b = YT.from_hdf5(file_to_read, dataset_name=key)
     @test all(a.value .== b.value)
-    @test a.units.unit_symbol == b.units.unit_symbol
+    @test a.units.unit_string == b.units.unit_string
 end
 
 # Special handling
@@ -43,7 +43,7 @@ prj = YT.Proj(ds, "density", 1, data_source=sp1)
 a = prj["density"]
 b = YT.from_hdf5(file_to_read, dataset_name="prj3")
 @test all(a.value .== b.value)
-@test a.units.unit_symbol == b.units.unit_symbol
+@test a.units.unit_string == b.units.unit_string
 
 # Cut region
 
@@ -53,7 +53,7 @@ cr = YT.CutRegion(sp2, conditions)
 a = cr["density"]
 b = YT.from_hdf5(file_to_read, dataset_name="cr")
 @test all(a.value .== b.value)
-@test a.units.unit_symbol == b.units.unit_symbol
+@test a.units.unit_string == b.units.unit_string
 kT = YT.YTQuantity(0.5, "keV")
 @test all(cr["kT"] .> kT)
 
@@ -69,7 +69,7 @@ for i in 1:3
     @test all(a.value .== b.value)
     @test all(a[1,2,3].value .== b[1,2,3].value)
     @test all(a[1:3,4:6,3:6].value .== b[1:3,4:6,3:6].value)
-    @test a.units.unit_symbol == b.units.unit_symbol
+    @test a.units.unit_string == b.units.unit_string
 end
 
 grids_subset = grids[5:num_grids-5]


### PR DESCRIPTION
These changes introduce precompilation to YT.jl. 

It is also now no longer necessary to depend on SymPy.jl. 

Tests on Julia 0.6 will fail due to a PyCall.jl bug (Issue https://github.com/JuliaPy/PyCall.jl/issues/332, which will hopefully be fixed by https://github.com/JuliaPy/PyCall.jl/pull/333).